### PR TITLE
fix: capitalize weekday names in month header

### DIFF
--- a/src/features/month-view/components/month-header/month-header.tsx
+++ b/src/features/month-view/components/month-header/month-header.tsx
@@ -62,8 +62,10 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({ className }) => {
             className="py-2 text-center font-medium border-r first:border-l"
             data-testid={`weekday-header-${weekDay}`}
           >
-            <span className="hidden text-sm sm:inline">{weekDay}</span>
-            <span className="text-xs sm:hidden">
+            <span className="hidden text-sm sm:inline capitalize">
+              {weekDay}
+            </span>
+            <span className="text-xs sm:hidden capitalize">
               {weekDays.shortDays[index]}
             </span>
           </motion.div>


### PR DESCRIPTION
## Summary
- Add `capitalize` CSS class to both full and abbreviated weekday names in month header
- Ensures consistent capitalization across desktop and mobile views
- Improves visual consistency and readability

## Test plan
- [ ] Verify weekday names are properly capitalized in month view header on desktop
- [ ] Verify abbreviated weekday names are properly capitalized on mobile
- [ ] Test responsive behavior when switching between desktop and mobile views

🤖 Generated with [Claude Code](https://claude.ai/code)