### PR TITLE
fix: remove viewPortProps spread to prevent React DOM warning

### DIFF
--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -8,7 +8,12 @@ interface ScrollAreaProps
   viewPortProps?: React.ComponentProps<typeof ScrollAreaPrimitive.Viewport>
 }
 
-function ScrollArea({ className, children, ...props }: ScrollAreaProps) {
+function ScrollArea({
+  className,
+  children,
+  viewPortProps,
+  ...props
+}: ScrollAreaProps) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -16,11 +21,10 @@ function ScrollArea({ className, children, ...props }: ScrollAreaProps) {
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
-        {...props.viewPortProps}
         data-slot="scroll-area-viewport"
         className={cn(
           'focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1',
-          props.viewPortProps?.className
+          viewPortProps?.className
         )}
       >
         {children}


### PR DESCRIPTION

## What changed?
Remove the spread of viewPortProps on ScrollAreaPrimitive.Viewport to fix React warning about unrecognized DOM props. Only extract and use the className property which is safe to apply to DOM elements.

This resolves the console warning:
'React does not recognize the viewPortProps prop on a DOM element'

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [ ] CI passes locally (`bun run ci`)
- [x] Changes are tested
- [x] Code follows project standards

Fixes #[5]
