### PR TITLE
feat: add classesOverride prop for custom disabled cell styling

### DIFF
--- a/src/components/demo/demo-calendar-settings.tsx
+++ b/src/components/demo/demo-calendar-settings.tsx
@@ -52,6 +52,8 @@ interface DemoCalendarSettingsProps {
   setStickyHeader?: (value: boolean) => void
   timeFormat: TimeFormat
   setTimeFormat: (value: TimeFormat) => void
+  useCustomClasses: boolean
+  setUseCustomClasses: (value: boolean) => void
   // Resource calendar specific props
   isResourceCalendar?: boolean
 }
@@ -87,6 +89,8 @@ export function DemoCalendarSettings({
   setStickyHeader,
   timeFormat,
   setTimeFormat,
+  useCustomClasses,
+  setUseCustomClasses,
   // Resource calendar props
   isResourceCalendar,
 }: DemoCalendarSettingsProps) {
@@ -402,6 +406,20 @@ export function DemoCalendarSettings({
             className="text-sm font-medium leading-none cursor-pointer"
           >
             Disable drag & drop
+          </label>
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="useCustomClasses"
+            checked={useCustomClasses}
+            onCheckedChange={() => setUseCustomClasses(!useCustomClasses)}
+          />
+          <label
+            htmlFor="useCustomClasses"
+            className="text-sm font-medium leading-none cursor-pointer"
+          >
+            Use custom disabled cell styles
           </label>
         </div>
       </CardContent>

--- a/src/components/demo/demo-page.tsx
+++ b/src/components/demo/demo-page.tsx
@@ -134,6 +134,7 @@ export function DemoPage() {
   const [calendarHeight, setCalendarHeight] = useState('600px')
   const [dayMaxEvents, setDayMaxEvents] = useState(3)
   const [timeFormat, setTimeFormat] = useState<TimeFormat>('12-hour')
+  const [useCustomClasses, setUseCustomClasses] = useState(false)
 
   const calendarKey = `${locale}-${initialView}-${initialDate?.toISOString() || 'today'}-${timeFormat}`
 
@@ -156,7 +157,10 @@ export function DemoPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 relative">
+    <div
+      data-testid="demo-page"
+      className="container mx-auto px-4 py-8 relative"
+    >
       {/* Decorative background elements */}
       <div className="fixed top-20 right-20 -z-10 w-96 h-96 bg-blue-500/10 rounded-full filter blur-3xl animate-pulse-slow"></div>
       <div className="fixed bottom-20 left-10 -z-10 w-80 h-80 bg-indigo-500/10 rounded-full filter blur-3xl animate-pulse"></div>
@@ -206,6 +210,8 @@ export function DemoPage() {
             setStickyHeader={setStickyHeader}
             timeFormat={timeFormat}
             setTimeFormat={setTimeFormat}
+            useCustomClasses={useCustomClasses}
+            setUseCustomClasses={setUseCustomClasses}
             // Resource calendar specific props
             isResourceCalendar={calendarType === 'resource'}
           />
@@ -277,6 +283,14 @@ export function DemoPage() {
                   dayMaxEvents={dayMaxEvents}
                   stickyViewHeader={stickyViewHeader}
                   timeFormat={timeFormat}
+                  classesOverride={
+                    useCustomClasses
+                      ? {
+                          disabledCell:
+                            'bg-red-50 dark:bg-red-950 text-red-400 dark:text-red-600 pointer-events-none opacity-50',
+                        }
+                      : undefined
+                  }
                   businessHours={[
                     {
                       daysOfWeek: ['monday', 'wednesday', 'friday'],
@@ -315,6 +329,14 @@ export function DemoPage() {
                   dayMaxEvents={dayMaxEvents}
                   stickyViewHeader={stickyViewHeader}
                   timeFormat={timeFormat}
+                  classesOverride={
+                    useCustomClasses
+                      ? {
+                          disabledCell:
+                            'bg-red-50 dark:bg-red-950 text-red-400 dark:text-red-600 pointer-events-none opacity-50',
+                        }
+                      : undefined
+                  }
                   businessHours={{
                     daysOfWeek: [
                       // 'monday',

--- a/src/components/droppable-cell.tsx
+++ b/src/components/droppable-cell.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { useDroppable } from '@dnd-kit/core'
 import React from 'react'
 import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
+import { DISABLED_CELL_CLASSNAME } from '@/lib/constants'
 
 interface DroppableCellProps {
   id: string
@@ -34,11 +35,12 @@ export function DroppableCell({
   'data-testid': dataTestId,
   disabled = false,
 }: DroppableCellProps) {
-  const { onCellClick, disableDragAndDrop, disableCellClick } =
+  const { onCellClick, disableDragAndDrop, disableCellClick, classesOverride } =
     useSmartCalendarContext((state) => ({
       onCellClick: state.onCellClick,
       disableDragAndDrop: state.disableDragAndDrop,
       disableCellClick: state.disableCellClick,
+      classesOverride: state.classesOverride,
     }))
 
   const { isOver, setNodeRef } = useDroppable({
@@ -83,7 +85,7 @@ export function DroppableCell({
         className,
         isOver && !disableDragAndDrop && !disabled && 'bg-accent',
         disableCellClick || disabled ? 'cursor-default' : 'cursor-pointer',
-        disabled && 'bg-secondary text-muted-foreground pointer-events-none'
+        disabled && (classesOverride?.disabledCell || DISABLED_CELL_CLASSNAME)
       )}
       onClick={handleCellClick}
       style={style}

--- a/src/components/grid-cell.tsx
+++ b/src/components/grid-cell.tsx
@@ -102,10 +102,9 @@ export const GridCell: React.FC<GridProps> = ({
         data-testid={`day-cell-${day.toISOString()}`}
         date={day}
         resourceId={resourceId}
-        disabled={!isBusiness}
+        disabled={!isBusiness || !isCurrentMonth}
         className={cn(
           'cursor-pointer overflow-clip p-1 hover:bg-accent min-h-[60px]',
-          !isCurrentMonth && 'bg-secondary text-muted-foreground',
           isLastColumn && 'border-r-0',
           className
         )}

--- a/src/features/calendar/components/ilamy-calendar.test.tsx
+++ b/src/features/calendar/components/ilamy-calendar.test.tsx
@@ -607,4 +607,149 @@ describe('IlamyCalendar', () => {
       })
     })
   })
+
+  describe('custom disabled state classesOverride', () => {
+    it('should apply default disabled state classes when no custom className is provided', async () => {
+      render(
+        <IlamyCalendar
+          events={[]}
+          initialView="month"
+          initialDate={dayjs('2025-01-15T00:00:00.000Z')}
+          businessHours={{
+            daysOfWeek: [
+              'monday',
+              'tuesday',
+              'wednesday',
+              'thursday',
+              'friday',
+            ],
+            startTime: 9,
+            endTime: 17,
+          }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('month-view')).toBeInTheDocument()
+      })
+
+      // Find a Saturday cell (non-business day) - should have default disabled styling
+      const saturdayCell = screen.getByTestId('day-cell-2025-01-18')
+      expect(saturdayCell).toHaveClass('bg-secondary')
+      expect(saturdayCell).toHaveClass('text-muted-foreground')
+    })
+
+    it('should apply custom disabledCell className when provided', async () => {
+      render(
+        <IlamyCalendar
+          events={[]}
+          initialView="month"
+          initialDate={dayjs('2025-01-15T00:00:00.000Z')}
+          businessHours={{
+            daysOfWeek: [
+              'monday',
+              'tuesday',
+              'wednesday',
+              'thursday',
+              'friday',
+            ],
+            startTime: 9,
+            endTime: 17,
+          }}
+          classesOverride={{
+            disabledCell: 'bg-gray-100 text-gray-400 cursor-not-allowed',
+          }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('month-view')).toBeInTheDocument()
+      })
+
+      // Find a Saturday cell (non-business day)
+      const saturdayCell = screen.getByTestId('day-cell-2025-01-18')
+      expect(saturdayCell).toHaveClass('bg-gray-100')
+      expect(saturdayCell).toHaveClass('text-gray-400')
+      expect(saturdayCell).toHaveClass('cursor-not-allowed')
+      // Should NOT have default classes
+      expect(saturdayCell).not.toHaveClass('bg-secondary')
+      expect(saturdayCell).not.toHaveClass('text-muted-foreground')
+    })
+
+    it('should apply custom disabledCell className in week view', async () => {
+      render(
+        <IlamyCalendar
+          events={[]}
+          initialView="week"
+          initialDate={dayjs('2025-01-15T00:00:00.000Z')}
+          businessHours={{
+            daysOfWeek: [
+              'monday',
+              'tuesday',
+              'wednesday',
+              'thursday',
+              'friday',
+            ],
+            startTime: 9,
+            endTime: 17,
+          }}
+          classesOverride={{
+            disabledCell: 'bg-red-50 text-red-300',
+          }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('week-view')).toBeInTheDocument()
+      })
+
+      // Find a time cell outside business hours (e.g., 8 AM)
+      // Week view uses time cells with format: week-time-cell-{date}-{hour}
+      const nonBusinessTimeCell = screen.getByTestId(
+        'week-time-cell-2025-01-13-08'
+      )
+      expect(nonBusinessTimeCell).toHaveClass('bg-red-50')
+      expect(nonBusinessTimeCell).toHaveClass('text-red-300')
+      // Should NOT have default classes
+      expect(nonBusinessTimeCell).not.toHaveClass('bg-secondary')
+      expect(nonBusinessTimeCell).not.toHaveClass('text-muted-foreground')
+    })
+
+    it('should apply custom disabledCell className in day view', async () => {
+      render(
+        <IlamyCalendar
+          events={[]}
+          initialView="day"
+          initialDate={dayjs('2025-01-15T00:00:00.000Z')}
+          businessHours={{
+            daysOfWeek: [
+              'monday',
+              'tuesday',
+              'wednesday',
+              'thursday',
+              'friday',
+            ],
+            startTime: 9,
+            endTime: 17,
+          }}
+          classesOverride={{
+            disabledCell: 'bg-yellow-50 text-yellow-300',
+          }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('day-view')).toBeInTheDocument()
+      })
+
+      // Find a time cell outside business hours (e.g., 8:00 AM)
+      // Day view uses time cells with format: day-time-cell-{hour}-{minute}
+      const nonBusinessTimeCell = screen.getByTestId('day-time-cell-08-00')
+      expect(nonBusinessTimeCell).toHaveClass('bg-yellow-50')
+      expect(nonBusinessTimeCell).toHaveClass('text-yellow-300')
+      // Should NOT have default classes
+      expect(nonBusinessTimeCell).not.toHaveClass('bg-secondary')
+      expect(nonBusinessTimeCell).not.toHaveClass('text-muted-foreground')
+    })
+  })
 })

--- a/src/features/calendar/components/ilamy-calendar.tsx
+++ b/src/features/calendar/components/ilamy-calendar.tsx
@@ -93,30 +93,12 @@ export const IlamyCalendar: React.FC<IlamyCalendarProps> = ({
   firstDayOfWeek = 'sunday',
   initialView = 'month',
   initialDate,
-  renderEvent,
-  renderEventForm,
-  onEventClick,
-  onCellClick,
-  onViewChange,
-  onEventAdd,
-  onEventUpdate,
-  onEventDelete,
-  onDateChange,
-  locale,
-  translations,
-  translator,
-  timezone,
-  disableCellClick,
-  disableEventClick,
-  disableDragAndDrop,
   dayMaxEvents = DAY_MAX_EVENTS_DEFAULT,
   eventSpacing = GAP_BETWEEN_ELEMENTS,
   stickyViewHeader = true,
   viewHeaderClassName = '',
-  headerComponent,
-  headerClassName,
-  businessHours,
   timeFormat = '12-hour',
+  ...props
 }) => {
   return (
     <CalendarProvider
@@ -124,30 +106,12 @@ export const IlamyCalendar: React.FC<IlamyCalendarProps> = ({
       firstDayOfWeek={WEEK_DAYS_NUMBER_MAP[firstDayOfWeek]}
       initialView={initialView}
       initialDate={safeDate(initialDate)}
-      renderEvent={renderEvent}
-      renderEventForm={renderEventForm}
-      onEventClick={onEventClick}
-      onCellClick={onCellClick}
-      onViewChange={onViewChange}
-      onEventAdd={onEventAdd}
-      onEventUpdate={onEventUpdate}
-      onEventDelete={onEventDelete}
-      onDateChange={onDateChange}
-      locale={locale}
-      translations={translations}
-      translator={translator}
-      timezone={timezone}
-      disableCellClick={disableCellClick}
-      disableEventClick={disableEventClick}
-      disableDragAndDrop={disableDragAndDrop}
       dayMaxEvents={dayMaxEvents}
       eventSpacing={eventSpacing}
       stickyViewHeader={stickyViewHeader}
       viewHeaderClassName={viewHeaderClassName}
-      headerComponent={headerComponent}
-      headerClassName={headerClassName}
-      businessHours={businessHours}
       timeFormat={timeFormat}
+      {...props}
     >
       <CalendarContent />
     </CalendarProvider>

--- a/src/features/calendar/components/month-view/day-cell.tsx
+++ b/src/features/calendar/components/month-view/day-cell.tsx
@@ -77,13 +77,12 @@ export const DayCell: React.FC<DayCellProps> = ({
         type="day-cell"
         data-testid={`day-cell-${day.format('YYYY-MM-DD')}`}
         date={day}
+        disabled={!isBusiness || !isCurrentMonth}
         className={cn(
           'cursor-pointer overflow-clip p-1 hover:bg-accent min-h-[60px]',
-          !isCurrentMonth && 'bg-secondary text-muted-foreground',
           isLastColumn && 'border-r-0',
           className
         )}
-        disabled={!isBusiness}
       >
         {/* Absolutely positioned multi-day bars (Google Calendar style) */}
 

--- a/src/features/calendar/contexts/calendar-context/context.ts
+++ b/src/features/calendar/contexts/calendar-context/context.ts
@@ -1,6 +1,9 @@
 import type { CalendarEvent, BusinessHours } from '@/components/types'
 import type { EventFormProps } from '@/components/event-form/event-form'
-import type { CellClickInfo } from '@/features/calendar/types'
+import type {
+  CellClickInfo,
+  CalendarClassesOverride,
+} from '@/features/calendar/types'
 import type { RecurrenceEditOptions } from '@/features/recurrence/types'
 import type dayjs from '@/lib/configs/dayjs-config'
 import type { TranslationKey } from '@/lib/translations/types'
@@ -59,6 +62,7 @@ export interface CalendarContextType {
   // Translation function
   t: (key: TranslationKey) => string
   timeFormat: TimeFormat
+  classesOverride?: CalendarClassesOverride
 }
 
 export const CalendarContext: React.Context<CalendarContextType | undefined> =

--- a/src/features/calendar/contexts/calendar-context/provider.tsx
+++ b/src/features/calendar/contexts/calendar-context/provider.tsx
@@ -4,7 +4,10 @@ import type { ReactNode } from 'react'
 import { CalendarContext } from './context'
 import type { CalendarEvent, BusinessHours } from '@/components/types'
 import type { EventFormProps } from '@/components/event-form/event-form'
-import type { CellClickInfo } from '@/features/calendar/types'
+import type {
+  CellClickInfo,
+  CalendarClassesOverride,
+} from '@/features/calendar/types'
 import type { Translations, TranslatorFunction } from '@/lib/translations/types'
 import { useCalendarEngine } from '@/hooks/use-calendar-engine'
 import type { CalendarView, TimeFormat } from '@/types'
@@ -41,6 +44,7 @@ export interface CalendarProviderProps {
   translations?: Translations
   translator?: TranslatorFunction
   timeFormat?: TimeFormat
+  classesOverride?: CalendarClassesOverride
 }
 
 export const CalendarProvider: React.FC<CalendarProviderProps> = ({
@@ -73,6 +77,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
   translations,
   translator,
   timeFormat = '12-hour',
+  classesOverride,
 }) => {
   // Use the calendar engine
   const calendarEngine = useCalendarEngine({
@@ -175,6 +180,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
       renderEventForm,
       t: calendarEngine.t,
       timeFormat,
+      classesOverride,
     }),
     [
       calendarEngine,
@@ -195,6 +201,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
       businessHours,
       renderEventForm,
       timeFormat,
+      classesOverride,
     ]
   )
 

--- a/src/features/calendar/types/index.ts
+++ b/src/features/calendar/types/index.ts
@@ -6,6 +6,20 @@ import type { Translations, TranslatorFunction } from '@/lib/translations/types'
 import type { CalendarView, TimeFormat } from '@/types'
 
 /**
+ * Custom class names for calendar styling.
+ * Allows users to override default styles for various calendar elements.
+ */
+export interface CalendarClassesOverride {
+  /**
+   * Class name for disabled cells (non-business hours).
+   * Replaces the DISABLED_CELL_CLASSNAME constant.
+   * @default "bg-secondary text-muted-foreground pointer-events-none"
+   * @example "bg-gray-100 text-gray-400 cursor-not-allowed"
+   */
+  disabledCell?: string
+}
+
+/**
  * This interface extends the base CalendarEvent but allows more flexible date types
  * for the start and end properties. The component will automatically convert these
  * to dayjs objects internally for consistent date handling.
@@ -179,4 +193,10 @@ export interface IlamyCalendarProps {
    * - "24-hour": Times displayed as "13:00"
    */
   timeFormat?: TimeFormat
+  /**
+   * Custom class names for overriding default calendar element styles.
+   * Allows fine-grained control over the appearance of different calendar elements.
+   * @example { disabledCell: "bg-gray-100 text-gray-400" }
+   */
+  classesOverride?: CalendarClassesOverride
 }

--- a/src/features/resource-calendar/components/ilamy-resource-calendar/ilamy-resource-calendar.tsx
+++ b/src/features/resource-calendar/components/ilamy-resource-calendar/ilamy-resource-calendar.tsx
@@ -19,31 +19,11 @@ export const IlamyResourceCalendar: React.FC<IlamyResourceCalendarProps> = ({
   firstDayOfWeek = 'sunday',
   initialView = 'month',
   initialDate,
-  renderEvent,
-  onEventClick,
-  onCellClick,
-  onViewChange,
-  onEventAdd,
-  onEventUpdate,
-  onEventDelete,
-  onDateChange,
-  locale,
-  timezone,
-  disableCellClick,
-  disableEventClick,
   disableDragAndDrop = false,
   dayMaxEvents = DAY_MAX_EVENTS_DEFAULT,
-  eventSpacing = GAP_BETWEEN_ELEMENTS,
-  stickyViewHeader,
-  viewHeaderClassName,
-  headerComponent,
-  headerClassName,
-  translations,
-  translator,
-  renderResource,
-  renderEventForm,
-  businessHours,
   timeFormat = '12-hour',
+  eventSpacing = GAP_BETWEEN_ELEMENTS,
+  ...props
 }) => {
   return (
     <ResourceCalendarProvider
@@ -54,31 +34,11 @@ export const IlamyResourceCalendar: React.FC<IlamyResourceCalendarProps> = ({
       firstDayOfWeek={WEEK_DAYS_NUMBER_MAP[firstDayOfWeek]}
       initialView={initialView}
       initialDate={safeDate(initialDate)}
-      renderEvent={renderEvent}
-      renderResource={renderResource}
-      onEventClick={onEventClick}
-      onCellClick={onCellClick}
-      onViewChange={onViewChange}
-      onEventAdd={onEventAdd}
-      onEventUpdate={onEventUpdate}
-      onEventDelete={onEventDelete}
-      onDateChange={onDateChange}
-      locale={locale}
-      timezone={timezone}
-      disableCellClick={disableCellClick}
-      disableEventClick={disableEventClick}
       disableDragAndDrop={disableDragAndDrop}
       dayMaxEvents={dayMaxEvents}
-      eventSpacing={eventSpacing}
-      stickyViewHeader={stickyViewHeader}
-      viewHeaderClassName={viewHeaderClassName}
-      headerComponent={headerComponent}
-      headerClassName={headerClassName}
-      translations={translations}
-      translator={translator}
-      renderEventForm={renderEventForm}
-      businessHours={businessHours}
       timeFormat={timeFormat}
+      eventSpacing={eventSpacing}
+      {...props}
     >
       <ResourceCalendarBody />
     </ResourceCalendarProvider>

--- a/src/features/resource-calendar/components/resource-event-grid.test.tsx
+++ b/src/features/resource-calendar/components/resource-event-grid.test.tsx
@@ -167,6 +167,7 @@ describe('ResourceEventGrid', () => {
       renderWithProvider(<ResourceEventGrid days={days} gridType="day" />, {
         resources: [mockResources[0]],
         businessHours,
+        initialDate: days[0],
       })
 
       const mondayCell = screen.getByTestId(`day-cell-${days[0].toISOString()}`)
@@ -194,6 +195,7 @@ describe('ResourceEventGrid', () => {
       renderWithProvider(<ResourceEventGrid days={hours} gridType="hour" />, {
         resources: [mockResources[0]],
         businessHours,
+        initialDate: monday,
       })
 
       const businessHourCell = screen.getByTestId(

--- a/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
+++ b/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { ResourceCalendarContext } from './context'
 import type { Resource } from '@/features/resource-calendar/types'
-import type { CellClickInfo } from '@/features/calendar/types'
+import type {
+  CellClickInfo,
+  CalendarClassesOverride,
+} from '@/features/calendar/types'
 import { useCalendarEngine } from '@/hooks/use-calendar-engine'
 import type { CalendarProviderProps } from '@/features/calendar/contexts/calendar-context/provider'
 import type { CalendarEvent } from '@/components/types'
@@ -20,6 +23,7 @@ interface ResourceCalendarProviderProps extends CalendarProviderProps {
   events?: CalendarEvent[]
   resources?: Resource[]
   renderResource?: (resource: Resource) => React.ReactNode
+  classesOverride?: CalendarClassesOverride
 }
 
 export const ResourceCalendarProvider: React.FC<
@@ -56,6 +60,7 @@ export const ResourceCalendarProvider: React.FC<
   renderEventForm,
   businessHours,
   timeFormat = '12-hour',
+  classesOverride,
 }) => {
   // Resource-specific state
   const [currentResources] = useState<Resource[]>(resources)
@@ -261,6 +266,7 @@ export const ResourceCalendarProvider: React.FC<
       viewHeaderClassName,
       businessHours,
       timeFormat,
+      classesOverride,
     }),
     [
       calendarEngine,
@@ -294,6 +300,7 @@ export const ResourceCalendarProvider: React.FC<
       headerClassName,
       businessHours,
       timeFormat,
+      classesOverride,
     ]
   )
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,6 +4,8 @@ export const GAP_BETWEEN_ELEMENTS = 1 // px (gap-1)
 export const DAY_NUMBER_HEIGHT = 28 // px (h-7)
 export const EVENT_BAR_HEIGHT = 24 // px (h-[24px])
 export const DAY_MAX_EVENTS_DEFAULT = 4 // Default max events per day
+export const DISABLED_CELL_CLASSNAME =
+  'bg-secondary text-muted-foreground pointer-events-none'
 
 export const WEEK_DAYS_NUMBER_MAP: Record<WeekDays, number> = {
   sunday: 0,


### PR DESCRIPTION
## Changes

- Added `classesOverride` prop to both regular and resource calendars for customizing disabled cell appearance
- Renamed from `classNames` to `classesOverride` for better clarity and grammatical correctness
- Removed `inactiveMonth` property from interface (unused)
- Extracted `DISABLED_CELL_CLASSNAME` constant to `lib/constants.ts` for consistency
- Added fallback logic in `DroppableCell` component
- Updated demo page with UI toggle to showcase custom disabled cell styling
- Updated all tests to use new `classesOverride` prop name

## Implementation Details

### Type Definition
\`\`\`typescript
export interface CalendarClassesOverride {
  disabledCell?: string
}
\`\`\`

### Constant
\`\`\`typescript
export const DISABLED_CELL_CLASSNAME = 'bg-secondary text-muted-foreground pointer-events-none'
\`\`\`

### Usage Pattern
\`\`\`typescript
<IlamyCalendar
  classesOverride={{
    disabledCell: 'bg-red-50 dark:bg-red-950 text-red-400 dark:text-red-600 pointer-events-none opacity-50'
  }}
/>
\`\`\`

