### PR TITLE
feat: add HiddenHeaderButtons configuration to control visibility of header buttons in the calendar

### DIFF
--- a/src/components/demo/demo-calendar-settings.tsx
+++ b/src/components/demo/demo-calendar-settings.tsx
@@ -15,6 +15,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@/components/ui/select'
+import type { HiddenHeaderButtons } from '@/features/calendar/types'
 import dayjs from '@/lib/configs/dayjs-config'
 import type { CalendarView, TimeFormat } from '@/types'
 import { ModeToggle } from './mode-toggle'
@@ -68,6 +69,10 @@ interface DemoCalendarSettingsProps {
 	setBusinessStartTime: (value: number) => void
 	businessEndTime: number
 	setBusinessEndTime: (value: number) => void
+	hiddenHeaderButtons: HiddenHeaderButtons
+	setHiddenHeaderButtons: React.Dispatch<
+		React.SetStateAction<HiddenHeaderButtons>
+	>
 }
 
 export function DemoCalendarSettings({
@@ -115,6 +120,8 @@ export function DemoCalendarSettings({
 	setBusinessStartTime,
 	businessEndTime,
 	setBusinessEndTime,
+	hiddenHeaderButtons,
+	setHiddenHeaderButtons,
 }: DemoCalendarSettingsProps) {
 	return (
 		<Card className="border bg-background backdrop-blur-md shadow-lg overflow-clip gap-0">
@@ -449,7 +456,7 @@ export function DemoCalendarSettings({
 						}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="customRenderer"
 					>
 						Use custom event renderer
@@ -464,7 +471,7 @@ export function DemoCalendarSettings({
 						}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="customTimeIndicator"
 					>
 						Use custom time indicator
@@ -480,7 +487,7 @@ export function DemoCalendarSettings({
 						}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="useCustomOnDateClick"
 					>
 						Use custom onCellClick handler
@@ -495,7 +502,7 @@ export function DemoCalendarSettings({
 						}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="useCustomOnEventClick"
 					>
 						Use custom onEventClick handler
@@ -508,7 +515,7 @@ export function DemoCalendarSettings({
 						onCheckedChange={() => setDisableCellClick(!disableCellClick)}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="disableCellClick"
 					>
 						Disable cell clicks
@@ -521,7 +528,7 @@ export function DemoCalendarSettings({
 						onCheckedChange={() => setDisableEventClick(!disableEventClick)}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="disableEventClick"
 					>
 						Disable event clicks
@@ -534,7 +541,7 @@ export function DemoCalendarSettings({
 						onCheckedChange={() => setDisableDragAndDrop(!disableDragAndDrop)}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="disableDragAndDrop"
 					>
 						Disable drag & drop
@@ -547,10 +554,68 @@ export function DemoCalendarSettings({
 						onCheckedChange={() => setUseCustomClasses(!useCustomClasses)}
 					/>
 					<label
-						className="text-sm font-medium leading-none cursor-pointer"
+						className="text-sm text-left font-medium leading-none cursor-pointer"
 						htmlFor="useCustomClasses"
 					>
 						Use custom disabled cell styles
+					</label>
+				</div>
+				<div className="h-px bg-gray-200 dark:bg-gray-800 my-4"></div>
+				<div className="text-sm text-left font-medium mb-1">
+					Header Settings
+				</div>
+				<div className="flex items-center space-x-2">
+					<Checkbox
+						checked={hiddenHeaderButtons.export}
+						id="hideHeaderButtonsExport"
+						onCheckedChange={() =>
+							setHiddenHeaderButtons({
+								...hiddenHeaderButtons,
+								export: !hiddenHeaderButtons.export,
+							})
+						}
+					/>
+					<label
+						className="text-sm text-left font-medium leading-none cursor-pointer"
+						htmlFor="hideHeaderButtonsExport"
+					>
+						Hide export button
+					</label>
+				</div>
+				<div className="flex items-center space-x-2">
+					<Checkbox
+						checked={hiddenHeaderButtons.newEvent}
+						id="hideHeaderButtonsNewEvent"
+						onCheckedChange={() =>
+							setHiddenHeaderButtons({
+								...hiddenHeaderButtons,
+								newEvent: !hiddenHeaderButtons.newEvent,
+							})
+						}
+					/>
+					<label
+						className="text-sm text-left font-medium leading-none cursor-pointer"
+						htmlFor="hideHeaderButtonsNewEvent"
+					>
+						Hide new event button
+					</label>
+				</div>
+				<div className="flex items-center space-x-2">
+					<Checkbox
+						checked={hiddenHeaderButtons.viewControls}
+						id="hideHeaderButtonsViewControls"
+						onCheckedChange={() =>
+							setHiddenHeaderButtons({
+								...hiddenHeaderButtons,
+								viewControls: !hiddenHeaderButtons.viewControls,
+							})
+						}
+					/>
+					<label
+						className="text-sm text-left font-medium leading-none cursor-pointer"
+						htmlFor="hideHeaderButtonsViewControls"
+					>
+						Hide view controls button
 					</label>
 				</div>
 			</CardContent>

--- a/src/components/demo/demo-page.tsx
+++ b/src/components/demo/demo-page.tsx
@@ -313,7 +313,11 @@ export function DemoPage() {
 	const [timeFormat, setTimeFormat] = useState<TimeFormat>('12-hour')
 	const [useCustomClasses, setUseCustomClasses] = useState(false)
 	const [useCustomTimeIndicator, setUseCustomTimeIndicator] = useState(false)
-
+	const [hiddenHeaderButtons, setHiddenHeaderButtons] = useState({
+		export: false,
+		newEvent: false,
+		viewControls: false,
+	})
 	// Resource calendar settings
 	const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>(
 		'horizontal'
@@ -398,6 +402,7 @@ export function DemoPage() {
 						disableDragAndDrop={disableDragAndDrop}
 						disableEventClick={disableEventClick}
 						firstDayOfWeek={firstDayOfWeek}
+						hiddenHeaderButtons={hiddenHeaderButtons}
 						hideNonBusinessHours={hideNonBusinessHours}
 						initialDate={initialDate}
 						initialView={initialView}
@@ -413,6 +418,7 @@ export function DemoPage() {
 						setDisableDragAndDrop={setDisableDragAndDrop}
 						setDisableEventClick={setDisableEventClick}
 						setFirstDayOfWeek={setFirstDayOfWeek}
+						setHiddenHeaderButtons={setHiddenHeaderButtons}
 						setHideNonBusinessHours={setHideNonBusinessHours}
 						setInitialDate={setInitialDate}
 						setInitialView={setInitialView}
@@ -428,9 +434,9 @@ export function DemoPage() {
 						setUseCustomTimeIndicator={setUseCustomTimeIndicator}
 						stickyViewHeader={stickyViewHeader}
 						timeFormat={timeFormat}
+						// Resource calendar specific props
 						timezone={timezone}
 						useCustomClasses={useCustomClasses}
-						// Resource calendar specific props
 						useCustomEventRenderer={useCustomEventRenderer}
 						useCustomOnDateClick={useCustomOnDateClick}
 						useCustomOnEventClick={useCustomOnEventClick}
@@ -495,6 +501,7 @@ export function DemoPage() {
 									disableEventClick={disableEventClick}
 									events={customEvents}
 									firstDayOfWeek={firstDayOfWeek}
+									hiddenHeaderButtons={hiddenHeaderButtons}
 									hideNonBusinessHours={hideNonBusinessHours}
 									initialDate={initialDate}
 									initialView={initialView}
@@ -537,6 +544,7 @@ export function DemoPage() {
 									disableEventClick={disableEventClick}
 									events={resourceEvents}
 									firstDayOfWeek={firstDayOfWeek}
+									hiddenHeaderButtons={hiddenHeaderButtons}
 									hideNonBusinessHours={hideNonBusinessHours}
 									initialDate={initialDate}
 									initialView={initialView === 'year' ? 'month' : initialView}

--- a/src/components/header/base-header.tsx
+++ b/src/components/header/base-header.tsx
@@ -29,6 +29,7 @@ const Header: React.FC<HeaderProps> = ({ className = '' }) => {
 		headerClassName,
 		rawEvents,
 		t,
+		hiddenHeaderButtons,
 	} = useSmartCalendarContext((ctx) => ({
 		view: ctx.view,
 		setView: ctx.setView,
@@ -40,6 +41,7 @@ const Header: React.FC<HeaderProps> = ({ className = '' }) => {
 		headerClassName: ctx.headerClassName,
 		rawEvents: ctx.rawEvents,
 		t: ctx.t,
+		hiddenHeaderButtons: ctx.hiddenHeaderButtons,
 	}))
 
 	const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
@@ -103,17 +105,19 @@ const Header: React.FC<HeaderProps> = ({ className = '' }) => {
 
 				<div className="flex flex-wrap justify-start @xl/base-header:justify-center gap-1 @4xl/base-header:justify-end overflow-x-auto">
 					<div className="hidden @md/base-header:flex items-center justify-start gap-1">
-						<ViewControls
-							className="justify-end"
-							currentView={view}
-							onChange={setView}
-							onNext={nextPeriod}
-							onPrevious={prevPeriod}
-							onToday={today}
-							variant="default"
-						/>
-						<NewEventButton />
-						<ExportButton />
+						{!hiddenHeaderButtons?.viewControls && (
+							<ViewControls
+								className="justify-end"
+								currentView={view}
+								onChange={setView}
+								onNext={nextPeriod}
+								onPrevious={prevPeriod}
+								onToday={today}
+								variant="default"
+							/>
+						)}
+						{!hiddenHeaderButtons?.newEvent && <NewEventButton />}
+						{!hiddenHeaderButtons?.export && <ExportButton />}
 					</div>
 
 					<div className="flex items-center justify-end gap-1 @md/base-header:hidden">

--- a/src/features/calendar/components/ilamy-calendar.tsx
+++ b/src/features/calendar/components/ilamy-calendar.tsx
@@ -69,6 +69,7 @@ export const IlamyCalendar: React.FC<IlamyCalendarProps> = ({
 	viewHeaderClassName = '',
 	timeFormat = '12-hour',
 	hideNonBusinessHours = false,
+	hiddenHeaderButtons,
 	...props
 }) => {
 	return (
@@ -77,6 +78,7 @@ export const IlamyCalendar: React.FC<IlamyCalendarProps> = ({
 			eventSpacing={eventSpacing}
 			events={normalizeEvents<IlamyCalendarPropEvent, CalendarEvent>(events)}
 			firstDayOfWeek={WEEK_DAYS_NUMBER_MAP[firstDayOfWeek]}
+			hiddenHeaderButtons={hiddenHeaderButtons}
 			hideNonBusinessHours={hideNonBusinessHours}
 			initialDate={safeDate(initialDate)}
 			initialView={initialView}

--- a/src/features/calendar/contexts/calendar-context/context.ts
+++ b/src/features/calendar/contexts/calendar-context/context.ts
@@ -4,6 +4,7 @@ import type { BusinessHours, CalendarEvent } from '@/components/types'
 import type {
 	CalendarClassesOverride,
 	CellClickInfo,
+	HiddenHeaderButtons,
 	RenderCurrentTimeIndicatorProps,
 } from '@/features/calendar/types'
 import type { RecurrenceEditOptions } from '@/features/recurrence/types'
@@ -68,6 +69,7 @@ export interface CalendarContextType {
 		props: RenderCurrentTimeIndicatorProps
 	) => React.ReactNode
 	hideNonBusinessHours?: boolean
+	hiddenHeaderButtons?: HiddenHeaderButtons
 }
 
 export const CalendarContext: React.Context<CalendarContextType | undefined> =

--- a/src/features/calendar/contexts/calendar-context/provider.tsx
+++ b/src/features/calendar/contexts/calendar-context/provider.tsx
@@ -6,6 +6,7 @@ import type { BusinessHours, CalendarEvent } from '@/components/types'
 import type {
 	CalendarClassesOverride,
 	CellClickInfo,
+	HiddenHeaderButtons,
 	RenderCurrentTimeIndicatorProps,
 } from '@/features/calendar/types'
 import { useCalendarEngine } from '@/hooks/use-calendar-engine'
@@ -51,6 +52,7 @@ export interface CalendarProviderProps {
 		props: RenderCurrentTimeIndicatorProps
 	) => ReactNode
 	hideNonBusinessHours?: boolean
+	hiddenHeaderButtons?: HiddenHeaderButtons
 }
 
 export const CalendarProvider: React.FC<CalendarProviderProps> = ({
@@ -86,6 +88,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 	classesOverride,
 	renderCurrentTimeIndicator,
 	hideNonBusinessHours = false,
+	hiddenHeaderButtons,
 }) => {
 	// Use the calendar engine
 	const calendarEngine = useCalendarEngine({
@@ -191,6 +194,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 			classesOverride,
 			renderCurrentTimeIndicator,
 			hideNonBusinessHours,
+			hiddenHeaderButtons,
 		}),
 		[
 			calendarEngine,
@@ -214,6 +218,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 			classesOverride,
 			renderCurrentTimeIndicator,
 			hideNonBusinessHours,
+			hiddenHeaderButtons,
 		]
 	)
 

--- a/src/features/calendar/types/index.ts
+++ b/src/features/calendar/types/index.ts
@@ -21,6 +21,19 @@ export interface CalendarClassesOverride {
 }
 
 /**
+ * Configuration for hiding header buttons in the calendar.
+ * Allows users to selectively hide export, new event, and view control buttons.
+ */
+export interface HiddenHeaderButtons {
+	/** Whether to hide the export button */
+	export?: boolean
+	/** Whether to hide the new event button */
+	newEvent?: boolean
+	/** Whether to hide the view controls button */
+	viewControls?: boolean
+}
+
+/**
  * This interface extends the base CalendarEvent but allows more flexible date types
  * for the start and end properties. The component will automatically convert these
  * to dayjs objects internally for consistent date handling.
@@ -258,4 +271,10 @@ export interface IlamyCalendarProps {
 	renderCurrentTimeIndicator?: (
 		props: RenderCurrentTimeIndicatorProps
 	) => React.ReactNode
+
+	/**
+	 * Configuration for hiding header buttons in the calendar.
+	 * Allows users to selectively hide export, new event, and view control buttons.
+	 */
+	hiddenHeaderButtons?: HiddenHeaderButtons
 }

--- a/src/features/resource-calendar/components/ilamy-resource-calendar/ilamy-resource-calendar.tsx
+++ b/src/features/resource-calendar/components/ilamy-resource-calendar/ilamy-resource-calendar.tsx
@@ -23,6 +23,7 @@ export const IlamyResourceCalendar: React.FC<IlamyResourceCalendarProps> = ({
 	dayMaxEvents = DAY_MAX_EVENTS_DEFAULT,
 	timeFormat = '12-hour',
 	eventSpacing = GAP_BETWEEN_ELEMENTS,
+	hiddenHeaderButtons,
 	...props
 }) => {
 	return (
@@ -34,6 +35,7 @@ export const IlamyResourceCalendar: React.FC<IlamyResourceCalendarProps> = ({
 				events
 			)}
 			firstDayOfWeek={WEEK_DAYS_NUMBER_MAP[firstDayOfWeek]}
+			hiddenHeaderButtons={hiddenHeaderButtons}
 			initialDate={safeDate(initialDate)}
 			initialView={initialView}
 			resources={resources}

--- a/src/features/resource-calendar/components/ilamy-resource-calendar/resource-calendar-body.tsx
+++ b/src/features/resource-calendar/components/ilamy-resource-calendar/resource-calendar-body.tsx
@@ -10,7 +10,6 @@ import { useResourceCalendarContext } from '@/features/resource-calendar/context
 
 export const ResourceCalendarBody: React.FC = () => {
 	const { view } = useResourceCalendarContext()
-
 	const viewMap = {
 		month: <ResourceMonthView key="month" />,
 		week: <ResourceWeekView key="week" />,

--- a/src/features/resource-calendar/contexts/resource-calendar-context/context.ts
+++ b/src/features/resource-calendar/contexts/resource-calendar-context/context.ts
@@ -4,7 +4,10 @@ import type {
 	CalendarContextType,
 	UseIlamyCalendarContextReturn,
 } from '@/features/calendar/contexts/calendar-context/context'
-import type { CellClickInfo } from '@/features/calendar/types'
+import type {
+	CellClickInfo,
+	HiddenHeaderButtons,
+} from '@/features/calendar/types'
 import type { Resource } from '@/features/resource-calendar/types'
 
 export interface ResourceCalendarContextType extends CalendarContextType {
@@ -27,6 +30,10 @@ export interface ResourceCalendarContextType extends CalendarContextType {
 	onCellClick: (info: CellClickInfo) => void
 	renderResource?: (resource: Resource) => React.ReactNode
 	orientation: 'horizontal' | 'vertical'
+	hiddenHeaderButtons?: HiddenHeaderButtons
+	setHiddenHeaderButtons?: React.Dispatch<
+		React.SetStateAction<HiddenHeaderButtons>
+	>
 }
 
 export const ResourceCalendarContext: React.Context<
@@ -53,6 +60,10 @@ export interface UseIlamyResourceCalendarContextReturn
 	readonly getEventsForResource: (
 		resourceId: string | number
 	) => CalendarEvent[]
+	readonly hiddenHeaderButtons?: HiddenHeaderButtons
+	readonly setHiddenHeaderButtons?: React.Dispatch<
+		React.SetStateAction<HiddenHeaderButtons>
+	>
 }
 
 export const useIlamyResourceCalendarContext =
@@ -85,5 +96,7 @@ export const useIlamyResourceCalendarContext =
 			closeEventForm: context.closeEventForm,
 			getEventsForResource: context.getEventsForResource,
 			businessHours: context.businessHours,
+			hiddenHeaderButtons: context.hiddenHeaderButtons,
+			setHiddenHeaderButtons: context.setHiddenHeaderButtons,
 		} as const
 	}

--- a/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
+++ b/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
@@ -5,6 +5,7 @@ import type { CalendarProviderProps } from '@/features/calendar/contexts/calenda
 import type {
 	CalendarClassesOverride,
 	CellClickInfo,
+	HiddenHeaderButtons,
 	RenderCurrentTimeIndicatorProps,
 } from '@/features/calendar/types'
 import type { Resource } from '@/features/resource-calendar/types'
@@ -31,6 +32,7 @@ interface ResourceCalendarProviderProps extends CalendarProviderProps {
 		props: RenderCurrentTimeIndicatorProps
 	) => React.ReactNode
 	hideNonBusinessHours?: boolean
+	hiddenHeaderButtons?: HiddenHeaderButtons
 }
 
 export const ResourceCalendarProvider: React.FC<
@@ -71,6 +73,7 @@ export const ResourceCalendarProvider: React.FC<
 	orientation = 'horizontal',
 	renderCurrentTimeIndicator,
 	hideNonBusinessHours = false,
+	hiddenHeaderButtons,
 }) => {
 	// Resource-specific state
 	const [currentResources] = useState<Resource[]>(resources)
@@ -280,6 +283,7 @@ export const ResourceCalendarProvider: React.FC<
 			orientation,
 			renderCurrentTimeIndicator,
 			hideNonBusinessHours,
+			hiddenHeaderButtons: hiddenHeaderButtons,
 		}),
 		[
 			calendarEngine,
@@ -317,6 +321,7 @@ export const ResourceCalendarProvider: React.FC<
 			orientation,
 			renderCurrentTimeIndicator,
 			hideNonBusinessHours,
+			hiddenHeaderButtons,
 		]
 	)
 

--- a/src/features/resource-calendar/types/index.ts
+++ b/src/features/resource-calendar/types/index.ts
@@ -1,4 +1,5 @@
 import type {
+	HiddenHeaderButtons,
 	IlamyCalendarPropEvent,
 	IlamyCalendarProps,
 } from '@/features/calendar/types'
@@ -32,6 +33,11 @@ export interface IlamyResourceCalendarProps
 	 * - "vertical": Resources are columns, time is rows
 	 */
 	orientation?: 'horizontal' | 'vertical'
+	/**
+	 * Configuration for hiding header buttons in the calendar.
+	 * Allows users to selectively hide export, new event, and view control buttons.
+	 */
+	hiddenHeaderButtons?: HiddenHeaderButtons
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type { UseIlamyCalendarContextReturn } from './features/calendar/contexts
 export { useIlamyCalendarContext } from './features/calendar/contexts/calendar-context/context'
 export type {
 	CellClickInfo,
+	HiddenHeaderButtons,
 	IlamyCalendarProps,
 	RenderCurrentTimeIndicatorProps,
 } from './features/calendar/types'


### PR DESCRIPTION
## What changed?

Refactored hiddenHeaderButtons to use a shared HiddenHeaderButtons type instead of inline definitions. The type is defined in src/features/calendar/types/index.ts and used across:
IlamyCalendarProps and IlamyResourceCalendarProps
CalendarProviderProps and CalendarContextType
ResourceCalendarProviderProps and ResourceCalendarContextType
UseIlamyResourceCalendarContextReturn
DemoCalendarSettingsProps


## Type of Change

- [ ] 🐛 Bug fix
- [ X] ✨ New feature
- [ ] 💥 Breaking change
- [ X] 📚 Documentation
- [X ] 🔧 Maintenance

## Checklist

- [X] CI passes locally (`bun run ci`)
- [X] Changes are tested
- [X] Code follows project standards
