### PR TITLE
fix: export BusinessHours from main entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export {
 	isRecurringEvent,
 } from '@/features/recurrence/utils/recurrence-handler'
 export type { EventFormProps } from './components/event-form/event-form'
-export type { CalendarEvent, WeekDays } from './components/types'
+export type { BusinessHours, CalendarEvent, WeekDays } from './components/types'
 export { IlamyCalendar } from './features/calendar/components/ilamy-calendar'
 export type { UseIlamyCalendarContextReturn } from './features/calendar/contexts/calendar-context/context'
 // Public calendar context hooks


### PR DESCRIPTION
Resolves #67. This PR exports the `BusinessHours` interface from the main entry point `src/index.ts`, which was previously missing despite being used in public props.