### PR TITLE
feat: add data-view attribute to DroppableCell contextually

### DIFF
--- a/src/components/droppable-cell.test.tsx
+++ b/src/components/droppable-cell.test.tsx
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { CalendarProvider } from '@/features/calendar/contexts/calendar-context/provider'
+import dayjs from '@/lib/configs/dayjs-config'
+import type { CalendarView } from '@/types'
+import { DroppableCell } from './droppable-cell'
+
+const initialDate = dayjs('2025-01-01T00:00:00.000Z')
+
+const renderDroppableCellWithView = (view: CalendarView) => {
+	return render(
+		<CalendarProvider
+			dayMaxEvents={3}
+			initialDate={initialDate}
+			initialView={view}
+		>
+			<DroppableCell
+				data-testid="test-droppable-cell"
+				date={initialDate}
+				id="test-cell"
+				type="day-cell"
+			/>
+		</CalendarProvider>
+	)
+}
+
+describe('DroppableCell data-view attribute', () => {
+	beforeEach(() => {
+		cleanup()
+	})
+
+	const views: CalendarView[] = ['month', 'week', 'day', 'year']
+
+	test.each(
+		views
+	)('should render data-view="%s" attribute from context', (view) => {
+		renderDroppableCellWithView(view)
+
+		const cell = screen.getByTestId('test-droppable-cell')
+		expect(cell.getAttribute('data-view')).toBe(view)
+	})
+})

--- a/src/components/droppable-cell.tsx
+++ b/src/components/droppable-cell.tsx
@@ -36,13 +36,19 @@ export function DroppableCell({
 	'data-testid': dataTestId,
 	disabled = false,
 }: DroppableCellProps) {
-	const { onCellClick, disableDragAndDrop, disableCellClick, classesOverride } =
-		useSmartCalendarContext((state) => ({
-			onCellClick: state.onCellClick,
-			disableDragAndDrop: state.disableDragAndDrop,
-			disableCellClick: state.disableCellClick,
-			classesOverride: state.classesOverride,
-		}))
+	const {
+		onCellClick,
+		disableDragAndDrop,
+		disableCellClick,
+		classesOverride,
+		view,
+	} = useSmartCalendarContext((state) => ({
+		onCellClick: state.onCellClick,
+		disableDragAndDrop: state.disableDragAndDrop,
+		disableCellClick: state.disableCellClick,
+		classesOverride: state.classesOverride,
+		view: state.view,
+	}))
 
 	const { isOver, setNodeRef } = useDroppable({
 		id,
@@ -78,7 +84,6 @@ export function DroppableCell({
 	}
 
 	return (
-		// oxlint-disable-next-line click-events-have-key-events
 		<div
 			className={cn(
 				'droppable-cell',
@@ -88,6 +93,7 @@ export function DroppableCell({
 				disabled && (classesOverride?.disabledCell || DISABLED_CELL_CLASSNAME)
 			)}
 			data-testid={dataTestId}
+			data-view={view}
 			onClick={handleCellClick}
 			ref={setNodeRef}
 			style={style}


### PR DESCRIPTION
This PR adds a `data-view` attribute to the `DroppableCell` component, pulling the current `view` from the calendar context. This enables CSS targeting based on the active view (month, week, day, etc.). Includes comprehensive unit tests in `droppable-cell.test.tsx`.