### PR TITLE
fix: scroll overflow in fixed-height calendar + DST grid fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ docs/
   export-ical.md                               # iCal export guide
   resource-calendar.md                         # Resource calendar docs
   translation-usage.md                         # i18n guide
+  time-grid.md                                 # Time grid architecture & DST handling
   logs/                                        # Daily dev logs (see Development Logs)
 ```
 

--- a/docs/logs/2026-02-28.md
+++ b/docs/logs/2026-02-28.md
@@ -1,0 +1,24 @@
+# Development Log - 2026-02-28
+
+## Changes
+
+- **[dnd]**: Fixed drag-and-drop to all-day row not working in week view. Root cause: `getWeekDays()` returns dates at midnight, so both the all-day cell and the 00:00 time grid cell produced identical droppable IDs (`day-cell-{date}T00:00:00.000Z`). The time cell registered after the all-day cell, overwriting it in @dnd-kit's droppable Map. Added `-allday` suffix to droppable IDs for all-day cells to prevent collision. Day view wasn't affected because `currentDate` includes the current time component, making the all-day cell ID unique from the midnight time cell.
+
+- **[dnd]**: Refactored `grid-cell.tsx` droppable ID and test ID construction — extracted `baseTestId` and `droppableId` variables for clarity. Removed debug `console.log` statements.
+
+## Files Modified
+
+- `src/components/grid-cell.tsx` - Added `-allday` suffix to droppable ID for all-day cells, cleaned up ID construction and removed debug logs
+- `src/components/grid-cell-spacing.test.tsx` - Added test verifying all-day and midnight time cells render as separate droppables
+
+- **[bugfix]**: Fixed events not extending full column width in day/week views. Root cause: the `<DroppableCell` opening tag in `grid-cell.tsx` was corrupted to `<Droppableertical-events-day-Cell` (likely from an accidental find-and-replace). React treated the unknown tag as a generic element, breaking the grid cell structure and event layout.
+
+## Files Modified
+
+- `src/components/grid-cell.tsx` - Added `-allday` suffix to droppable ID for all-day cells, cleaned up ID construction, removed debug logs, fixed corrupted component tag name
+- `src/components/grid-cell-spacing.test.tsx` - Added test verifying all-day and midnight time cells render as separate droppables
+
+## Notes
+
+- The droppable ID (`day.toISOString()`) and the test ID (`day.format('YYYY-MM-DD')`) are constructed independently — changing the droppable ID does not affect test assertions.
+- The DnD handler (`dnd-utils.ts`) uses `over.data.current` (not `over.id`) to process drops, so the ID change is safe.

--- a/docs/logs/2026-03-01.md
+++ b/docs/logs/2026-03-01.md
@@ -1,0 +1,31 @@
+# Development Log - 2026-03-01
+
+## Changes
+
+- **[bugfix]**: Fixed DST bug where random "3 AM" cells appeared in week view on spring-forward days. Two root causes:
+  1. **Key collision**: `dayjs.hour(2)` returns hour 3 on DST spring-forward day, producing duplicate React keys ("03"). Fixed in `vertical-grid-col.tsx` by using array index (`dayIndex`) in keys instead of hour string.
+  2. **Shared hour template**: All 7 week columns shared a single hour array, so one DST day corrupted all columns. Fixed by having each column call `getViewHours` per-day.
+
+- **[refactor]**: `getDayHours` uses `startOf('day').hour(i)` — each row maps to "the hour labeled i", keeping grid rows aligned across columns in week views. On DST spring-forward, `.hour(2)` returns 3 AM (collapsed, not skipped), which is correct for grid alignment since 6 of 7 week days still have a valid 2 AM.
+
+- **[refactor]**: Simplified `getViewHours` — returns `getDayHours({ referenceDate })` directly (no remapping). Extracted `hasBusinessHoursConfig` and `shouldFilterByBusinessHours` variables for readability. Early returns instead of mutable state.
+
+- **[cleanup]**: Removed `remapHoursToDate` utility function — no longer needed since `getDayHours` returns hours on the actual reference date and `getViewHours` passes `referenceDate` through.
+
+## Files Modified
+
+- `src/lib/utils/date-utils.ts` - `getDayHours` uses `startOf('day').hour(i)`, removed `remapHoursToDate`
+- `src/lib/utils/date-utils.test.ts` - Updated tests for new `getDayHours` signature, removed `remapHoursToDate` tests
+- `src/features/calendar/utils/view-hours.ts` - Simplified: passes `referenceDate` to `getDayHours`, returns directly, readable variable names
+- `src/components/vertical-grid/vertical-grid-col.tsx` - Key fix: uses `dayIndex` in React keys
+- `src/features/calendar/components/day-view/day-view.tsx` - Uses `getViewHours` result directly
+- `src/features/calendar/components/week-view/week-view.tsx` - Each column calls `getViewHours` per-day
+- `src/features/resource-calendar/components/day-view/resource-day-vertical.tsx` - Uses hours directly
+- `src/features/resource-calendar/components/day-view/resource-day-horizontal.tsx` - Uses hours directly
+- `src/features/resource-calendar/components/week-view/resource-week-vertical.tsx` - Remaps hours per-day
+- `src/features/resource-calendar/components/week-view/resource-week-horizontal.tsx` - Calls `getViewHours` per-day
+
+## Notes
+
+- Tests run in UTC (no DST), so DST bugs aren't caught by `bun test`. The bug manifests in browsers with DST timezones (e.g., America/Halifax where March 8, 2026 springs forward at 2 AM).
+- `.hour(i)` is correct for grid alignment: in a week view, row N should represent "hour N" across all 7 columns. `.add(i, 'hour')` would misalign the DST column since hours shift after the spring-forward point. On DST day, `.hour(2)` and `.hour(3)` both yield 3 AM, but the `dayIndex` key fix prevents React collisions.

--- a/docs/time-grid.md
+++ b/docs/time-grid.md
@@ -1,0 +1,169 @@
+# Time Grid Architecture
+
+Internal documentation for the vertical time grid used in day and week views (both standard and resource calendar).
+
+## Data Flow
+
+```
+getDayHours({ referenceDate })     Generate 24 hourly slots for a date
+        |
+getViewHours({ referenceDate })    Filter by business hours if enabled
+        |
+   View component                  Build columns, pass to VerticalGrid
+        |
+   VerticalGrid                    Render grid rows + event overlay
+        |
+   VerticalGridCol                 Render cells per column
+```
+
+## Hour Generation
+
+### getDayHours
+
+`src/lib/utils/date-utils.ts`
+
+Generates 24 dayjs objects for a given date, one per hour (0-23).
+
+```typescript
+getDayHours({ referenceDate, length? })
+// Returns: [referenceDate@00:00, referenceDate@01:00, ..., referenceDate@23:00]
+```
+
+Uses `startOfDay.hour(i)` so that row N always represents "the hour labeled N". This keeps grid rows aligned across all columns in a week view.
+
+### getViewHours
+
+`src/features/calendar/utils/view-hours.ts`
+
+Wraps `getDayHours` with optional business hours filtering. When `hideNonBusinessHours` is enabled, it filters hours to the business range (e.g., 9-17).
+
+```typescript
+getViewHours({ referenceDate, businessHours?, hideNonBusinessHours?, allDates?, resourceBusinessHours? })
+```
+
+- `allDates`: For week views, the union of all business hours across days determines the visible range.
+- `resourceBusinessHours`: Additional business hours from resources are merged when calculating the range.
+
+## View Patterns
+
+### Day Views (single column)
+
+Day views call `getViewHours` once with `currentDate` and use the result for both the time column and the day column.
+
+```typescript
+const hours = getViewHours({ referenceDate: currentDate, ... })
+const timeCol = { days: hours, ... }
+const dayCol  = { days: hours, ... }
+```
+
+Applies to: `day-view.tsx`, `resource-day-vertical.tsx`, `resource-day-horizontal.tsx`
+
+### Week Views (multiple columns)
+
+Each column calls `getViewHours` with its own day as `referenceDate`. This ensures each column gets hours on the correct date.
+
+```typescript
+const columns = weekDays.map((day) => ({
+  days: getViewHours({ referenceDate: day, ... }),
+  ...
+}))
+```
+
+The shared time column (left gutter) uses a single `getViewHours` call with `currentDate` for display labels only.
+
+Applies to: `week-view.tsx`, `resource-week-vertical.tsx`, `resource-week-horizontal.tsx`
+
+## DST Handling
+
+### The Problem
+
+On DST spring-forward days (e.g., March 8, 2026 in America/Halifax), 2 AM doesn't exist. `dayjs('2026-03-08').hour(2)` returns a dayjs object with `.hour() === 3`.
+
+This causes two issues:
+1. **Duplicate hour values**: Both `.hour(2)` and `.hour(3)` return hour 3, producing duplicate React keys.
+2. **Shared template corruption**: If all week columns share one hour array generated from a DST day, every column gets the corrupted hours.
+
+### The Fix
+
+Two changes prevent the bug:
+
+**1. Array-index keys in VerticalGridCol** (`vertical-grid-col.tsx`)
+
+React keys use the array index (`dayIndex`) instead of the hour string:
+
+```typescript
+// Before (broken on DST): key={`${id}-${hourStr}`}       -- duplicate "03"
+// After (correct):         key={`${id}-${dayIndex}-${hourStr}`}
+```
+
+This prevents React from confusing two cells that happen to have the same hour value.
+
+**2. Per-day hour generation in week views**
+
+Each column generates its own hours via `getViewHours({ referenceDate: day })`. A DST day only affects its own column — the other 6 days are unaffected.
+
+### Why .hour(i) over .add(i, 'hour')
+
+`.hour(i)` sets the hour label. `.add(i, 'hour')` offsets from midnight.
+
+On a spring-forward day:
+
+| Index | `.hour(i)` | `.add(i, 'hour')` |
+|-------|------------|--------------------|
+| 0     | 0 AM       | 0 AM               |
+| 1     | 1 AM       | 1 AM               |
+| 2     | 3 AM *     | 3 AM               |
+| 3     | 3 AM *     | 4 AM               |
+| 4     | 4 AM       | 5 AM               |
+| ...   | ...        | ... (shifted +1)   |
+| 23    | 11 PM      | 12 AM next day     |
+
+`.hour(i)` produces a duplicate at hour 3 but keeps rows aligned across week columns — row 9 is always "9 AM" in every column. `.add(i, 'hour')` avoids the duplicate but shifts the DST column by one row, misaligning it with the other 6 days.
+
+Since the `dayIndex` key fix handles the duplicate, `.hour(i)` is correct for grid alignment.
+
+### Testing Limitation
+
+`bun test` runs in UTC, which has no DST transitions. DST bugs can only be verified manually in the browser with a DST timezone (e.g., `TZ=America/Halifax`).
+
+## VerticalGrid Component
+
+`src/components/vertical-grid/vertical-grid.tsx`
+
+Renders the grid structure: header, optional all-day row, and scrollable body with time rows.
+
+### Props
+
+- `columns`: Array of column definitions, each with `id`, `days` (hour slots), `day` (calendar date), `gridType`, and optional `renderCell`.
+- `gridType`: `'hour'` for time-based grids.
+- `cellSlots`: Sub-hour divisions (e.g., `[0, 15, 30, 45]` for 15-min slots).
+- `allDayRow`: Optional all-day event row rendered above the grid.
+- `variant`: `'regular'` for standard calendar, omit for resource calendar.
+
+### Column Definition
+
+```typescript
+{
+  id: string              // Unique column ID (e.g., 'day-col-2025-06-15')
+  day?: dayjs.Dayjs       // Calendar date (undefined for time column)
+  days: dayjs.Dayjs[]     // Hour slots for this column
+  gridType: 'hour'
+  className?: string
+  noEvents?: boolean      // True for the time-label column
+  renderCell?: (date) =>  // Custom cell renderer (used by time column)
+  resourceId?: string     // For resource calendar columns
+  resource?: Resource     // For resource calendar columns
+}
+```
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/lib/utils/date-utils.ts` | `getDayHours` — generates hourly slots |
+| `src/features/calendar/utils/view-hours.ts` | `getViewHours` — filters by business hours |
+| `src/features/calendar/utils/business-hours.ts` | `calculateBusinessHoursRange` — computes min/max hours |
+| `src/components/vertical-grid/vertical-grid.tsx` | Grid layout and structure |
+| `src/components/vertical-grid/vertical-grid-col.tsx` | Column rendering with DST-safe keys |
+| `src/components/vertical-grid/vertical-grid-events-layer.tsx` | Event overlay positioning |
+| `src/components/grid-cell.tsx` | Individual droppable grid cell |

--- a/src/components/demo/demo-page.tsx
+++ b/src/components/demo/demo-page.tsx
@@ -280,7 +280,7 @@ export function DemoPage() {
 		return Intl.DateTimeFormat().resolvedOptions().timeZone
 	})
 	const [stickyViewHeader, setStickyHeader] = useState(true)
-	const [hideNonBusinessHours, setHideNonBusinessHours] = useState(true)
+	const [hideNonBusinessHours, setHideNonBusinessHours] = useState(false)
 	const [businessStartTime, setBusinessStartTime] = useState(9)
 	const [businessEndTime, setBusinessEndTime] = useState(17)
 

--- a/src/components/grid-cell-spacing.test.tsx
+++ b/src/components/grid-cell-spacing.test.tsx
@@ -57,3 +57,68 @@ describe('GridCell Event Spacing', () => {
 		expect(placeholders[1].style.height).toBe(`${EVENT_BAR_HEIGHT}px`)
 	})
 })
+
+describe('GridCell droppable ID uniqueness', () => {
+	beforeEach(() => {
+		cleanup()
+	})
+
+	test('all-day cell and midnight time cell for the same date render as separate droppable elements', () => {
+		const midnightDate = dayjs('2025-01-13T00:00:00.000Z')
+		render(
+			<CalendarProvider dayMaxEvents={3} initialDate={midnightDate}>
+				<GridCell allDay day={midnightDate} gridType="day" />
+				<GridCell
+					day={midnightDate}
+					gridType="hour"
+					hour={0}
+					shouldRenderEvents={false}
+				/>
+			</CalendarProvider>
+		)
+
+		// Both cells render with distinct test IDs
+		expect(screen.getByTestId('day-cell-2025-01-13')).toBeInTheDocument()
+		expect(screen.getByTestId('day-cell-2025-01-13-00-00')).toBeInTheDocument()
+
+		// They are separate droppable cell DOM nodes (not sharing the same @dnd-kit registration)
+		const allDayDroppable = screen
+			.getByTestId('day-cell-2025-01-13')
+			.closest('.droppable-cell')
+		const timeDroppable = screen
+			.getByTestId('day-cell-2025-01-13-00-00')
+			.closest('.droppable-cell')
+		expect(allDayDroppable).not.toBe(timeDroppable)
+	})
+
+	test('time cells for different hours on the same day render as separate droppable elements', () => {
+		const date = dayjs('2025-01-13T00:00:00.000Z')
+		render(
+			<CalendarProvider dayMaxEvents={3} initialDate={date}>
+				<GridCell
+					day={date.hour(9)}
+					gridType="hour"
+					hour={9}
+					shouldRenderEvents={false}
+				/>
+				<GridCell
+					day={date.hour(10)}
+					gridType="hour"
+					hour={10}
+					shouldRenderEvents={false}
+				/>
+			</CalendarProvider>
+		)
+
+		expect(screen.getByTestId('day-cell-2025-01-13-09-00')).toBeInTheDocument()
+		expect(screen.getByTestId('day-cell-2025-01-13-10-00')).toBeInTheDocument()
+
+		const cell9 = screen
+			.getByTestId('day-cell-2025-01-13-09-00')
+			.closest('.droppable-cell')
+		const cell10 = screen
+			.getByTestId('day-cell-2025-01-13-10-00')
+			.closest('.droppable-cell')
+		expect(cell9).not.toBe(cell10)
+	})
+})

--- a/src/components/grid-cell.tsx
+++ b/src/components/grid-cell.tsx
@@ -121,10 +121,13 @@ const NoMemoGridCell: React.FC<GridProps> = ({
 
 	const hourStr = day.format('HH')
 	const mm = day.format('mm')
-	const dateTestIdBase =
-		gridType === 'hour'
-			? `day-cell-${day.format('YYYY-MM-DD')}-${hourStr}-${mm}`
-			: `day-cell-${day.format('YYYY-MM-DD')}`
+	const baseTestId = `day-cell-${day.format('YYYY-MM-DD')}`
+	const testId =
+		gridType === 'hour' ? `${baseTestId}-${hourStr}-${mm}` : baseTestId
+	// Droppable ID must use toISOString() (not YYYY-MM-DD) so each time slot
+	// gets a unique ID in @dnd-kit's registry. YYYY-MM-DD strips the time,
+	// causing all cells on the same day to collide.
+	const droppableId = `day-cell-${day.toISOString()}${allDay ? '-allday' : ''}${resourceId ? `-resource-${resourceId}` : ''}`
 
 	return (
 		<>
@@ -134,11 +137,11 @@ const NoMemoGridCell: React.FC<GridProps> = ({
 					'cursor-pointer overflow-clip p-1 hover:bg-accent min-h-[60px] relative border-r last:border-r-0 only:border-r border-b',
 					className
 				)}
-				data-testid={dataTestId || dateTestIdBase}
+				data-testid={dataTestId || testId}
 				date={day}
 				disabled={!isBusiness || !isCurrentMonth}
 				hour={hour}
-				id={`day-cell-${day.toISOString()}${resourceId ? `-resource-${resourceId}` : ''}`}
+				id={droppableId}
 				minute={minute}
 				resourceId={resourceId}
 				type="day-cell"

--- a/src/components/horizontal-grid/horizontal-grid.tsx
+++ b/src/components/horizontal-grid/horizontal-grid.tsx
@@ -8,8 +8,6 @@ import {
 	type HorizontalGridRowProps,
 } from './horizontal-grid-row'
 
-const BODY_HEIGHT = 'h-[calc(100%-3rem)]'
-
 interface HorizontalGridProps {
 	rows: HorizontalGridRowProps[]
 	children?: React.ReactNode
@@ -41,18 +39,17 @@ export const HorizontalGrid: React.FC<HorizontalGridProps> = ({
 	)
 
 	return (
-		<div className="h-full" data-testid="horizontal-grid-container">
+		<div
+			className="h-full flex flex-col"
+			data-testid="horizontal-grid-container"
+		>
 			{/**
 			 * header row is rendered outside scroll area for regular calendar
 			 */}
 			{isRegularCalendar && header}
 
 			<ScrollArea
-				className={cn(
-					'h-full',
-					isRegularCalendar && 'overflow-auto',
-					isRegularCalendar && BODY_HEIGHT // scroll area becomes body in regular calendar
-				)}
+				className={cn('h-full', isRegularCalendar && 'overflow-auto')}
 				data-testid="horizontal-grid-scroll"
 				viewPortProps={{ className: '*:flex! *:flex-col! *:min-h-full' }}
 			>
@@ -63,11 +60,7 @@ export const HorizontalGrid: React.FC<HorizontalGridProps> = ({
 
 				{/* Calendar area with scroll */}
 				<div
-					className={cn(
-						'flex flex-1 w-fit',
-						isResourceCalendar && BODY_HEIGHT, // this becomes body in resource calendar
-						classes?.body
-					)}
+					className={cn('flex flex-1 w-fit', classes?.body)}
 					data-testid="horizontal-grid-body"
 				>
 					<div

--- a/src/components/vertical-grid/vertical-grid-col.tsx
+++ b/src/components/vertical-grid/vertical-grid-col.tsx
@@ -54,7 +54,7 @@ const NoMemoVerticalGridCol: React.FC<VerticalGridColProps> = ({
 					gridTemplateRows: `repeat(${days.length}, minmax(0, 1fr))`,
 				}}
 			>
-				{days.map((day) => {
+				{days.map((day, dayIndex) => {
 					const hourStr = day.format('HH')
 					const dateStr = day.format('YYYY-MM-DD')
 
@@ -67,7 +67,7 @@ const NoMemoVerticalGridCol: React.FC<VerticalGridColProps> = ({
 							<div
 								className="h-[60px] border-b border-r"
 								data-testid={testId}
-								key={`${dateStr}-${hourStr}`}
+								key={`${id}-${dayIndex}-${hourStr}`}
 							>
 								{renderCell(day)}
 							</div>
@@ -90,7 +90,7 @@ const NoMemoVerticalGridCol: React.FC<VerticalGridColProps> = ({
 								day={m ? day.minute(m) : day}
 								gridType={gridType}
 								hour={day.hour()}
-								key={`${dateStr}-${hourStr}-${mm}-${resourceId || 'no-resource'}`}
+								key={`${id}-${dayIndex}-${mm}`}
 								minute={m}
 								resourceId={resourceId} // Events are rendered in a separate layer
 								shouldRenderEvents={false}

--- a/src/components/vertical-grid/vertical-grid-events-layer.tsx
+++ b/src/components/vertical-grid/vertical-grid-events-layer.tsx
@@ -53,7 +53,7 @@ const NoMemoVerticalGridEventsLayer: React.FC<VerticalGridEventsLayerProps> = ({
 						}}
 					>
 						<DraggableEvent
-							className={cn('pointer-events-auto absolute', {
+							className={cn('pointer-events-auto', {
 								'[&_p]:text-[10px] [&_p]:mt-0': isShortEvent,
 							})}
 							elementId={eventKey}

--- a/src/components/vertical-grid/vertical-grid-header-container.tsx
+++ b/src/components/vertical-grid/vertical-grid-header-container.tsx
@@ -35,10 +35,7 @@ const NoMemoVerticalGridHeaderContainer: React.FC<
 			{/* All-day row */}
 			{allDayRow && (
 				<div
-					className={cn(
-						'flex w-full border-b min-h-12 h-full',
-						classes?.allDay
-					)}
+					className={cn('flex w-full border-b min-h-12', classes?.allDay)}
 					data-testid="vertical-grid-all-day"
 				>
 					{allDayRow}

--- a/src/components/vertical-grid/vertical-grid.test.tsx
+++ b/src/components/vertical-grid/vertical-grid.test.tsx
@@ -73,4 +73,28 @@ describe('VerticalGrid', () => {
 			'custom-allday-class'
 		)
 	})
+
+	test('container uses flex column layout for scroll containment', () => {
+		renderVerticalGrid()
+
+		const container = screen.getByTestId('vertical-grid-container')
+		expect(container.className).toContain('flex')
+		expect(container.className).toContain('flex-col')
+	})
+
+	test('scroll area is present for regular variant', () => {
+		renderVerticalGrid({ variant: 'regular' })
+
+		const scrollArea = screen.getByTestId('vertical-grid-scroll')
+		expect(scrollArea).toBeInTheDocument()
+	})
+
+	test('all-day row container has minimum height', () => {
+		renderVerticalGrid({
+			allDayRow: <div data-testid="mock-all-day">All Day</div>,
+		})
+
+		const allDayContainer = screen.getByTestId('vertical-grid-all-day')
+		expect(allDayContainer.className).toContain('min-h-12')
+	})
 })

--- a/src/components/vertical-grid/vertical-grid.tsx
+++ b/src/components/vertical-grid/vertical-grid.tsx
@@ -4,8 +4,6 @@ import { cn } from '@/lib/utils'
 import { VerticalGridCol, type VerticalGridColProps } from './vertical-grid-col'
 import { VerticalGridHeaderContainer } from './vertical-grid-header-container'
 
-const BODY_HEIGHT = 'h-[calc(100%-3rem)]'
-
 interface VerticalGridProps {
 	columns: VerticalGridColProps[]
 	children?: React.ReactNode
@@ -42,16 +40,12 @@ export const VerticalGrid: React.FC<VerticalGridProps> = ({
 	)
 
 	return (
-		<div className="h-full" data-testid="vertical-grid-container">
+		<div className="h-full flex flex-col" data-testid="vertical-grid-container">
 			{/* header row */}
 			{isRegularCalendar && header}
 
 			<ScrollArea
-				className={cn(
-					'h-full',
-					isRegularCalendar && 'overflow-auto',
-					isRegularCalendar && BODY_HEIGHT // scroll area becomes body in regular calendar
-				)}
+				className={cn('h-full', isRegularCalendar && 'overflow-auto')}
 				data-testid="vertical-grid-scroll"
 				viewPortProps={{ className: '*:flex! *:flex-col! *:min-h-full' }}
 			>
@@ -59,11 +53,7 @@ export const VerticalGrid: React.FC<VerticalGridProps> = ({
 				{isResourceCalendar && header}
 				{/* Calendar area with scroll */}
 				<div
-					className={cn(
-						'flex flex-1 w-fit',
-						isResourceCalendar && BODY_HEIGHT,
-						classes?.body
-					)}
+					className={cn('flex flex-1 w-fit', classes?.body)}
 					data-testid="vertical-grid-body"
 				>
 					{/* Day columns with time slots */}

--- a/src/features/calendar/components/day-view/day-view.test.tsx
+++ b/src/features/calendar/components/day-view/day-view.test.tsx
@@ -709,6 +709,18 @@ describe('DayView', () => {
 		expect(screen.getByTestId('vertical-time-23')).toBeInTheDocument()
 	})
 
+	test('scroll area uses flex column container for scroll containment', () => {
+		cleanup()
+		renderDayView()
+
+		const container = screen.getByTestId('vertical-grid-container')
+		expect(container.className).toContain('flex')
+		expect(container.className).toContain('flex-col')
+
+		const scrollArea = screen.getByTestId('vertical-grid-scroll')
+		expect(scrollArea).toBeInTheDocument()
+	})
+
 	test('still applies business hours styling when hideNonBusinessHours is false', () => {
 		cleanup()
 		const monday = dayjs('2025-01-06T00:00:00.000Z')

--- a/src/features/calendar/components/day-view/day-view.tsx
+++ b/src/features/calendar/components/day-view/day-view.tsx
@@ -53,14 +53,18 @@ export const DayView = () => {
 		<VerticalGrid
 			allDayRow={<AllDayRow days={[currentDate]} />}
 			cellSlots={[0, 15, 30, 45]}
-			classes={{ header: 'w-full', body: 'w-full', allDay: 'w-full' }}
+			classes={{
+				header: 'w-full',
+				body: 'w-full',
+				allDay: 'w-full',
+			}}
 			columns={[firstCol, columns]}
 			gridType="hour"
 			variant="regular"
 		>
 			{/* Header */}
 			<div
-				className={'flex h-full flex-1 justify-center items-center'}
+				className={'flex flex-1 justify-center items-center min-h-12'}
 				data-testid="day-view-header"
 			>
 				<AnimatedSection

--- a/src/features/calendar/components/week-view/week-view.test.tsx
+++ b/src/features/calendar/components/week-view/week-view.test.tsx
@@ -772,6 +772,18 @@ describe('WeekView', () => {
 		expect(screen.getByTestId('vertical-time-23')).toBeInTheDocument()
 	})
 
+	test('scroll area uses flex column container for scroll containment', () => {
+		cleanup()
+		renderWeekView()
+
+		const container = screen.getByTestId('vertical-grid-container')
+		expect(container.className).toContain('flex')
+		expect(container.className).toContain('flex-col')
+
+		const scrollArea = screen.getByTestId('vertical-grid-scroll')
+		expect(scrollArea).toBeInTheDocument()
+	})
+
 	test('still applies business hours styling when hideNonBusinessHours is false', () => {
 		cleanup()
 		const monday = dayjs('2025-01-06T00:00:00.000Z')

--- a/src/features/calendar/components/week-view/week-view.tsx
+++ b/src/features/calendar/components/week-view/week-view.tsx
@@ -58,19 +58,22 @@ export const WeekView: React.FC = () => {
 		),
 	}
 
-	// Generate week days
+	// Generate week days — each column gets its own hours on the correct date
 	const columns = useMemo(() => {
 		return weekDays.map((day) => ({
 			id: `day-col-${day.format('YYYY-MM-DD')}`,
 			day,
 			label: day.format('D'),
 			className: CELL_CLASS,
-			days: hours.map((h) =>
-				day.hour(h.hour()).minute(0).second(0).millisecond(0)
-			),
+			days: getViewHours({
+				referenceDate: day,
+				businessHours,
+				hideNonBusinessHours,
+				allDates: weekDays,
+			}),
 			value: day,
 		}))
-	}, [weekDays, hours])
+	}, [weekDays, businessHours, hideNonBusinessHours])
 
 	return (
 		<VerticalGrid
@@ -80,7 +83,7 @@ export const WeekView: React.FC = () => {
 					days={weekDays}
 				/>
 			}
-			classes={{ header: 'w-full h-18', body: 'h-[calc(100%-4.5rem)] w-full' }}
+			classes={{ header: 'w-full h-18', body: 'w-full' }}
 			columns={[firstCol, ...columns]}
 			gridType="hour"
 			variant="regular"

--- a/src/features/calendar/utils/view-hours.ts
+++ b/src/features/calendar/utils/view-hours.ts
@@ -31,14 +31,14 @@ export function getViewHours({
 	allDates = [referenceDate],
 	resourceBusinessHours = [],
 }: GetViewHoursOptions): dayjs.Dayjs[] {
-	const allHours = getDayHours({ referenceDate })
+	const hours = getDayHours({ referenceDate })
 
-	if (
-		!hideNonBusinessHours ||
-		(!businessHours && resourceBusinessHours.length === 0)
-	) {
-		return allHours
-	}
+	const hasBusinessHoursConfig =
+		!!businessHours || resourceBusinessHours.length > 0
+	const shouldFilterByBusinessHours =
+		hideNonBusinessHours && hasBusinessHoursConfig
+
+	if (!shouldFilterByBusinessHours) return hours
 
 	const { minStart, maxEnd, hasBusinessHours } = calculateBusinessHoursRange({
 		allDates,
@@ -47,12 +47,9 @@ export function getViewHours({
 		hideNonBusinessHours,
 	})
 
-	if (!hasBusinessHours) {
-		return allHours
-	}
+	if (!hasBusinessHours) return hours
 
-	// Return hours within the range [minStart, maxEnd)
-	return allHours.filter((h) => {
+	return hours.filter((h) => {
 		const hour = h.hour()
 		return hour >= minStart && hour < maxEnd
 	})

--- a/src/features/resource-calendar/components/week-view/resource-week-vertical.tsx
+++ b/src/features/resource-calendar/components/week-view/resource-week-vertical.tsx
@@ -74,13 +74,19 @@ export const ResourceWeekVertical: React.FC = () => {
 					resourceId: resource.id,
 					resource,
 					day,
-					days: hours.map((h) =>
-						day.hour(h.hour()).minute(0).second(0).millisecond(0)
-					),
+					days: getViewHours({
+						referenceDate: day,
+						businessHours,
+						hideNonBusinessHours,
+						allDates: weekDays,
+						resourceBusinessHours: resources
+							.map((r) => r.businessHours)
+							.filter(Boolean) as (BusinessHours | BusinessHours[])[],
+					}),
 					gridType: 'hour' as const,
 				}))
 			),
-		[resources, weekDays, hours]
+		[resources, weekDays, businessHours, hideNonBusinessHours]
 	)
 	return (
 		<VerticalGrid

--- a/src/lib/utils/date-utils.test.ts
+++ b/src/lib/utils/date-utils.test.ts
@@ -1,6 +1,47 @@
 import { describe, expect, it } from 'bun:test'
 import dayjs from '@/lib/configs/dayjs-config'
-import { getWeekDays } from './date-utils'
+import { getDayHours, getWeekDays } from './date-utils'
+
+describe('getDayHours', () => {
+	it('should return exactly 24 hours by default', () => {
+		const hours = getDayHours()
+		expect(hours).toHaveLength(24)
+	})
+
+	it('should return hours with sequential .hour() values 0-23', () => {
+		const hours = getDayHours()
+		hours.forEach((h, i) => {
+			expect(h.hour()).toBe(i)
+		})
+	})
+
+	it('should return hours on the reference date', () => {
+		const referenceDate = dayjs('2025-06-15T00:00:00.000Z')
+		const hours = getDayHours({ referenceDate })
+
+		expect(hours).toHaveLength(24)
+		hours.forEach((h, i) => {
+			expect(h.hour()).toBe(i)
+			expect(h.format('YYYY-MM-DD')).toBe('2025-06-15')
+		})
+	})
+
+	it('should produce unique timestamps (each entry is a distinct moment)', () => {
+		const hours = getDayHours()
+
+		const timestamps = hours.map((h) => h.valueOf())
+		const uniqueTimestamps = new Set(timestamps)
+		expect(uniqueTimestamps.size).toBe(24)
+	})
+
+	it('should respect custom length', () => {
+		const hours = getDayHours({ length: 12 })
+		expect(hours).toHaveLength(12)
+		hours.forEach((h, i) => {
+			expect(h.hour()).toBe(i)
+		})
+	})
+})
 
 describe('getWeekDays', () => {
 	describe('Sunday as first day of week (0)', () => {

--- a/src/lib/utils/date-utils.ts
+++ b/src/lib/utils/date-utils.ts
@@ -61,15 +61,23 @@ export function getMonthDays(monthDate: dayjs.Dayjs): dayjs.Dayjs[] {
 }
 
 interface GetDayHoursOptions {
-	referenceDate?: dayjs.Dayjs // Reference date to set the hours on (default is today)
-	length?: number // Number of hours in the day (default is 24)
+	referenceDate?: dayjs.Dayjs
+	length?: number
 }
 
+/**
+ * Generates an array of 24 dayjs objects representing hourly slots for a day.
+ * Uses .hour(i) so each row maps to "the hour labeled i" — keeping grid rows
+ * aligned across columns in week views. On DST spring-forward, .hour(2) returns
+ * 3 AM (the non-existent hour is collapsed), but the grid key fix (dayIndex)
+ * and per-day generation in views handle this correctly.
+ */
 export function getDayHours({
 	referenceDate = dayjs(),
 	length = 24,
 }: GetDayHoursOptions = {}): dayjs.Dayjs[] {
+	const startOfDay = referenceDate.startOf('day')
 	return Array.from({ length }, (_, i) =>
-		referenceDate.hour(i).minute(0).second(0).millisecond(0)
+		startOfDay.hour(i).minute(0).second(0).millisecond(0)
 	)
 }


### PR DESCRIPTION
## Summary

- **Fix scroll area overflow** in fixed-height calendar: last row (e.g., 11 PM) was cut off in day/week views. Replaced `h-[calc(100%-3rem)]` body height with `flex flex-col` layout so the scroll area fills remaining space naturally. Closes #83.
- **Fix DST spring-forward grid corruption**: on DST days, `dayjs.hour(2)` returns hour 3, causing duplicate React keys and shared-template corruption across week columns. Fixed with array-index keys in `VerticalGridCol` and per-day `getViewHours` calls in week views.
- **Fix all-day droppable ID collision**: all-day cell and midnight time cell had identical `@dnd-kit` droppable IDs. Added `-allday` suffix.
- **Fix corrupted `DroppableCell` tag name** that broke event layout in day/week views.
- **Simplify `getViewHours`** with early returns and descriptive variables.
- **Add `docs/time-grid.md`** documenting the vertical grid architecture, DST handling, and `.hour(i)` vs `.add(i, 'hour')` tradeoffs.

## Test plan

- [x] All 682 tests pass (`bun test`)
- [ ] Verify fixed-height calendar scrolls to 11 PM fully in day and week views
- [ ] Verify week view navigation across DST boundary (e.g., March 8, 2026 in America/Halifax) shows no duplicate "3 AM" cells
- [ ] Verify drag-and-drop to all-day row works in week view
- [ ] Verify events render full column width in day/week views