### PR TITLE
fix: move prev next date callback out of updater

### DIFF
--- a/src/components/header/base-header.test.tsx
+++ b/src/components/header/base-header.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, mock } from 'bun:test'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import type { CalendarEvent } from '@/components/types'
 import { CalendarProvider } from '@/features/calendar/contexts/calendar-context/provider'
 import dayjs from '@/lib/configs/dayjs-config'
@@ -24,6 +25,29 @@ const mockDownloadICalendar = mock()
 mock.module('@/lib/utils/export-ical', () => ({
 	downloadICalendar: mockDownloadICalendar,
 }))
+
+const HeaderWithParentDateState = ({
+	initialDate,
+}: {
+	initialDate: dayjs.Dayjs
+}) => {
+	const [currentDate, setCurrentDate] = useState(initialDate)
+
+	return (
+		<>
+			<div data-testid="selected-date">{currentDate.format('YYYY-MM-DD')}</div>
+			<CalendarProvider
+				dayMaxEvents={3}
+				events={[]}
+				firstDayOfWeek={0}
+				initialDate={currentDate}
+				onDateChange={(date) => setCurrentDate(date)}
+			>
+				<Header />
+			</CalendarProvider>
+		</>
+	)
+}
 
 describe('Header with Export Button', () => {
 	const testEvents: CalendarEvent[] = [
@@ -94,5 +118,44 @@ describe('Header with Export Button', () => {
 			expect.stringMatching(/calendar-\d{4}-\d{2}-\d{2}\.ics/),
 			'ilamy Calendar'
 		)
+	})
+	it('should not warn when prev/next navigation updates parent-owned date state', async () => {
+		const originalConsoleError = console.error
+		const consoleError = mock((..._args: unknown[]) => {})
+		console.error = consoleError as typeof console.error
+
+		try {
+			render(
+				<HeaderWithParentDateState
+					initialDate={dayjs('2025-08-04T09:00:00.000Z')}
+				/>
+			)
+
+			const nextButton = screen
+				.getAllByRole('button')
+				.find((button) => button.querySelector('svg.lucide-chevron-right'))
+
+			if (!nextButton) {
+				throw new Error('Next button not found')
+			}
+
+			await act(async () => {
+				fireEvent.click(nextButton)
+			})
+
+			await waitFor(() => {
+				expect(screen.getByTestId('selected-date')).toHaveTextContent(
+					'2025-09-04'
+				)
+			})
+
+			expect(
+				consoleError.mock.calls.some((args) =>
+					String(args[0]).includes('Cannot update a component')
+				)
+			).toBe(false)
+		} finally {
+			console.error = originalConsoleError
+		}
 	})
 })

--- a/src/hooks/use-calendar-engine.ts
+++ b/src/hooks/use-calendar-engine.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { BusinessHours, CalendarEvent } from '@/components/types'
 import type { RecurrenceEditOptions } from '@/features/recurrence/types'
 import {
@@ -199,35 +199,38 @@ export const useCalendarEngine = (
 		}
 	}, [timezone])
 
-	const selectDate = useCallback(
-		(date: dayjs.Dayjs) => {
-			setCurrentDate(date)
-			onDateChange?.(date)
-		},
-		[onDateChange]
-	)
+	// Fire onDateChange after any navigation that updates currentDate.
+	// Using a ref + effect keeps the callback out of state updaters,
+	// avoiding the "Cannot update a component while rendering" warning.
+	const prevDateRef = useRef(currentDate)
+	useEffect(() => {
+		if (!currentDate.isSame(prevDateRef.current)) {
+			prevDateRef.current = currentDate
+			onDateChange?.(currentDate)
+		}
+	}, [currentDate, onDateChange])
+
+	const selectDate = useCallback((date: dayjs.Dayjs) => {
+		setCurrentDate(date)
+	}, [])
 
 	const navigatePeriod = useCallback(
 		(direction: 1 | -1) => {
-			const newDate =
-				direction === 1
-					? currentDate.add(1, VIEW_UNITS[view])
-					: currentDate.subtract(1, VIEW_UNITS[view])
-
-			setCurrentDate(newDate)
-			onDateChange?.(newDate)
+			setCurrentDate((prev) => {
+				return direction === 1
+					? prev.add(1, VIEW_UNITS[view])
+					: prev.subtract(1, VIEW_UNITS[view])
+			})
 		},
-		[currentDate, view, onDateChange]
+		[view]
 	)
 
 	const nextPeriod = useCallback(() => navigatePeriod(1), [navigatePeriod])
 	const prevPeriod = useCallback(() => navigatePeriod(-1), [navigatePeriod])
 
 	const today = useCallback(() => {
-		const newDate = dayjs()
-		setCurrentDate(newDate)
-		onDateChange?.(newDate)
-	}, [onDateChange])
+		setCurrentDate(dayjs())
+	}, [])
 
 	const addEvent = useCallback(
 		(event: CalendarEvent) => {

--- a/src/hooks/use-calendar-engine.ts
+++ b/src/hooks/use-calendar-engine.ts
@@ -209,16 +209,15 @@ export const useCalendarEngine = (
 
 	const navigatePeriod = useCallback(
 		(direction: 1 | -1) => {
-			setCurrentDate((prev) => {
-				const newDate =
-					direction === 1
-						? prev.add(1, VIEW_UNITS[view])
-						: prev.subtract(1, VIEW_UNITS[view])
-				onDateChange?.(newDate)
-				return newDate
-			})
+			const newDate =
+				direction === 1
+					? currentDate.add(1, VIEW_UNITS[view])
+					: currentDate.subtract(1, VIEW_UNITS[view])
+
+			setCurrentDate(newDate)
+			onDateChange?.(newDate)
 		},
-		[view, onDateChange]
+		[currentDate, view, onDateChange]
 	)
 
 	const nextPeriod = useCallback(() => navigatePeriod(1), [navigatePeriod])


### PR DESCRIPTION
## What changed?

This changes prev/next navigation so ilamy no longer calls `onDateChange` from inside the `setCurrentDate` updater.

- compute `newDate` outside the updater
- call `setCurrentDate(newDate)`
- call `onDateChange?.(newDate)` after that

This avoids the React warning path while keeping prev/next navigation behavior and callback semantics the same from the caller's point of view.

It also adds a stock-header regression test that renders the calendar with parent-owned date state, clicks the built-in prev/next navigation, and verifies the React warning is not emitted.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [x] CI passes locally (`bun run ci`)
- [x] Changes are tested
- [x] Code follows project standards
