### PR TITLE
feat(calendar-engine): fire onDateChange when view changes

### DIFF
--- a/docs/api-parity-checklist.md
+++ b/docs/api-parity-checklist.md
@@ -1,0 +1,58 @@
+# API Parity Checklist (vs FullCalendar)
+
+Feature gaps compared to FullCalendar and other mature calendar libraries. Prioritized by impact.
+
+## Tier 1: High-Impact
+
+- [ ] **`revert()` on event drop** — `onEventUpdate` should pass a `revert()` function so consumers can undo a failed server save without re-rendering the entire event list
+- [ ] **`oldEvent` in mutation callbacks** — `onEventUpdate`, `onEventDelete` should pass both old and new event state so consumers can diff changes or validate before accepting
+- [ ] **Date range selection (`onSelect`)** — Fire callback when user drag-selects a date range (not just single click). Standard UX for creating multi-day events. Requires `selectable` prop
+- [ ] **Lazy event loading (`events` as function)** — Allow `events` to be an async function `(range, success, failure) => void` for on-demand fetching. Critical for large datasets
+- [ ] **`loading` callback** — `loading(isLoading: boolean)` fires when async event fetch starts/stops. Enables showing a spinner during data loading
+
+## Tier 2: Important for Specific Use Cases
+
+- [ ] **Event resize** — `onEventResize` with delta. User drags event edge to change duration. Currently only drag-to-move is supported
+- [ ] **External event dragging** — `onEventReceive` / `onDrop`. Drag elements from outside the calendar onto a cell to create events. Requires interaction with external `@dnd-kit` sources
+- [ ] **Pre-validation hooks** — `eventAllow(info) => boolean` and `selectAllow(info) => boolean`. Prevent invalid mutations before they happen (e.g., no events on weekends, no overlaps). Currently mutations are applied immediately with no way to prevent them
+- [ ] **`delta` in DnD callbacks** — `onEventUpdate` should include `{ delta: { days: number, hours: number, minutes: number } }` so consumers don't need to manually diff old/new dates
+- [ ] **`slotMinTime` / `slotMaxTime`** — Control visible time range independently of business hours. Currently `hideNonBusinessHours` is all-or-nothing
+
+## Tier 3: Polish
+
+- [ ] **`jsEvent` in callbacks** — Include the browser MouseEvent/PointerEvent in `onEventClick`, `onCellClick`, etc. Enables context menus, tooltips, and position-aware UI
+- [ ] **`el` (DOM element) in callbacks** — Include the target DOM element in callbacks. Enables highlighting, measuring, and custom positioning
+- [ ] **Nav link callbacks** — `onNavLinkDayClick(date)` and `onNavLinkWeekClick(weekStart)`. Customize what happens when clicking day/week numbers in headers (e.g., navigate to day view)
+- [ ] **`allDaySlot` toggle** — Allow hiding the all-day row in day/week views
+- [ ] **`slotLabelFormat` / `eventTimeFormat`** — Customize time label formatting beyond `12-hour` / `24-hour`
+- [ ] **`resourcesSet` callback** — Fire when resources are initialized or changed (analogous to `datesSet` for dates)
+- [ ] **Resources as function** — Allow `resources` to be an async function for lazy loading, like the proposed `events` function
+
+## Already Implemented (Parity or Better)
+
+- [x] `onDateChange` with visible range — matches FullCalendar's `datesSet`
+- [x] `onDateChange` fires on view switch — standard behavior
+- [x] `onCellClick` with `CellClickInfo` including `resourceId` — matches `dateClick`
+- [x] `onEventClick` — matches `eventClick`
+- [x] `onEventAdd` / `onEventUpdate` / `onEventDelete` — matches `eventAdd` / `eventChange` / `eventRemove`
+- [x] `onViewChange` — matches view change callbacks
+- [x] Recurring event CRUD with scope (this/following/all) — FullCalendar doesn't have this built-in
+- [x] `renderEvent` / `renderResource` / `renderCurrentTimeIndicator` — flexible custom rendering
+- [x] `hiddenDays` — hide specific weekdays
+- [x] Resource-specific business hours
+- [x] `businessHours` with split shifts
+- [x] `disableCellClick` / `disableEventClick` / `disableDragAndDrop` — interaction control
+- [x] `firstDayOfWeek` — configurable week start
+- [x] Full timezone support via `timezone` prop
+- [x] i18n via `translations` / `translator` props
+
+## References
+
+- [FullCalendar eventDrop](https://fullcalendar.io/docs/eventDrop)
+- [FullCalendar select callback](https://fullcalendar.io/docs/select-callback)
+- [FullCalendar datesSet](https://fullcalendar.io/docs/datesSet)
+- [FullCalendar events function](https://fullcalendar.io/docs/events-function)
+- [FullCalendar loading](https://fullcalendar.io/docs/loading)
+- [FullCalendar eventResize](https://fullcalendar.io/docs/eventResize)
+- [FullCalendar external dragging](https://fullcalendar.io/docs/external-dragging)
+- [React Big Calendar onRangeChange](https://github.com/jquense/react-big-calendar/pull/641)

--- a/docs/logs/2026-04-04.md
+++ b/docs/logs/2026-04-04.md
@@ -33,3 +33,14 @@
 - The `dayEventsMap` groups events by day key (`YYYY-MM-DD`) using the already-filtered week-level events. This is one pass over a small pre-filtered list, replacing 7 separate `getEventsForDateRange` calls per row.
 - `GroupedColumn` exists because React hooks can't be called inside map callbacks — each grouped column (resource week horizontal) needs its own `useProcessedWeekEvents` call with a different `days` array.
 - The timezone reactive update (`setCurrentDate` + `setCurrentEvents` with `.tz()`) was kept because events come from user props and don't get re-created when timezone changes. Without it, stored events would display in the original timezone forever.
+
+- **[feat]**: Fire `onDateChange` when view changes.
+  - When switching views (e.g., month → week), the visible date range changes (42 days → 7 days) but `onDateChange` was not fired. Consumers fetching events from a backend would miss this range change.
+  - Both FullCalendar (`datesSet`) and React Big Calendar (`onRangeChange`) fire their range callback on view changes — this is the standard approach.
+  - `handleViewChange` now calls `onDateChange(currentDate, range)` with the range computed for the new view.
+  - Does NOT fire on initial mount — too risky for consumers who only expect it on user interaction.
+
+## Files Modified (onDateChange on view switch)
+
+- `src/hooks/use-calendar-engine.ts` — added `onDateChange` call in `handleViewChange`
+- `src/hooks/use-calendar-engine.test.ts` — added test for onDateChange firing on view switch

--- a/src/hooks/use-calendar-engine.test.ts
+++ b/src/hooks/use-calendar-engine.test.ts
@@ -935,5 +935,31 @@ describe('useCalendarEngine', () => {
 			expect(range.start.format('YYYY-MM-DD')).toBe('2025-12-21')
 			expect(range.end.format('YYYY-MM-DD')).toBe('2025-12-27')
 		})
+
+		it('should fire onDateChange when view changes (month → week)', () => {
+			const { result } = renderHook(() =>
+				useCalendarEngine({
+					...defaultConfig,
+					initialDate, // Jan 15, 2025 (Wednesday)
+					initialView: 'month',
+					firstDayOfWeek: 0,
+					onDateChange,
+				})
+			)
+
+			// Switch from month to week — visible range changes from 42 days to 7 days
+			act(() => result.current.setView('week'))
+
+			expect(onDateChange).toHaveBeenCalledTimes(1)
+			const [date, range] = onDateChange.mock.calls[0]
+
+			// Date should be the same (Jan 15)
+			expect(date.format('YYYY-MM-DD')).toBe('2025-01-15')
+
+			// Range should be the week containing Jan 15 (Sunday start)
+			// Jan 12 (Sun) to Jan 18 (Sat)
+			expect(range.start.format('YYYY-MM-DD')).toBe('2025-01-12')
+			expect(range.end.format('YYYY-MM-DD')).toBe('2025-01-18')
+		})
 	})
 })

--- a/src/hooks/use-calendar-engine.ts
+++ b/src/hooks/use-calendar-engine.ts
@@ -359,8 +359,11 @@ export const useCalendarEngine = (
 		(newView: CalendarView) => {
 			setView(newView)
 			onViewChange?.(newView)
+			// View change affects visible range — notify consumers
+			const range = calculateViewRange(currentDate, newView, firstDayOfWeek)
+			onDateChange?.(currentDate, range)
 		},
-		[onViewChange]
+		[onViewChange, onDateChange, currentDate, firstDayOfWeek]
 	)
 
 	const findParentRecurringEvent = useCallback(


### PR DESCRIPTION
## Summary

- Fire `onDateChange` when the view changes (e.g., month → week → day)
- The visible date range changes when switching views (42 days → 7 days → 1 day) but `onDateChange` was not fired, causing consumers fetching events from a backend to miss the range change
- This is the standard approach — both FullCalendar (`datesSet`) and React Big Calendar (`onRangeChange`) fire their range callback on view changes
- Does **not** fire on initial mount

## Test plan

- [x] All tests pass (`bun run ci`)
- [x] New test: "should fire onDateChange when view changes (month → week)" verifies correct range
- [ ] Manual: switch views and confirm `onDateChange` fires with correct range