### PR TITLE
feat: add renderHour prop for custom hour formatting

### DIFF
--- a/src/components/demo/demo-calendar-settings.tsx
+++ b/src/components/demo/demo-calendar-settings.tsx
@@ -68,6 +68,8 @@ interface DemoCalendarSettingsProps {
 	setUseCustomClasses: (value: boolean) => void
 	useCustomTimeIndicator: boolean
 	setUseCustomTimeIndicator: (value: boolean) => void
+	useCustomHourRenderer: boolean
+	setUseCustomHourRenderer: (value: boolean) => void
 	// Resource calendar specific props
 	isResourceCalendar?: boolean
 	orientation?: 'horizontal' | 'vertical'
@@ -121,6 +123,8 @@ export function DemoCalendarSettings({
 	setUseCustomClasses,
 	useCustomTimeIndicator,
 	setUseCustomTimeIndicator,
+	useCustomHourRenderer,
+	setUseCustomHourRenderer,
 	// Resource calendar props
 	isResourceCalendar,
 	orientation,
@@ -535,6 +539,21 @@ export function DemoCalendarSettings({
 						htmlFor="customTimeIndicator"
 					>
 						Use custom time indicator
+					</label>
+				</div>
+				<div className="flex items-center space-x-2">
+					<Checkbox
+						checked={useCustomHourRenderer}
+						id="customHourRenderer"
+						onCheckedChange={() =>
+							setUseCustomHourRenderer(!useCustomHourRenderer)
+						}
+					/>
+					<label
+						className="text-sm font-medium leading-none cursor-pointer"
+						htmlFor="customHourRenderer"
+					>
+						Use custom hour renderer
 					</label>
 				</div>
 

--- a/src/components/demo/demo-page.tsx
+++ b/src/components/demo/demo-page.tsx
@@ -311,6 +311,7 @@ export function DemoPage() {
 	const [timeFormat, setTimeFormat] = useState<TimeFormat>('12-hour')
 	const [useCustomClasses, setUseCustomClasses] = useState(false)
 	const [useCustomTimeIndicator, setUseCustomTimeIndicator] = useState(false)
+	const [useCustomHourRenderer, setUseCustomHourRenderer] = useState(false)
 	const [hiddenDays, setHiddenDays] = useState<WeekDays[]>([])
 
 	// Resource calendar settings
@@ -337,7 +338,6 @@ export function DemoPage() {
 			</div>
 		)
 	}
-
 	// Custom current time indicator renderer
 	const renderCurrentTimeIndicator = ({
 		currentTime,
@@ -362,6 +362,18 @@ export function DemoPage() {
 				)}
 				{/* Red line extends across all columns */}
 				<div className="flex-1 bg-red-500" />
+			</div>
+		)
+	}
+
+	// Custom hour renderer function
+	const renderHour = (date: Dayjs) => {
+		return (
+			<div className="flex flex-col items-center leading-tight">
+				<span className="font-bold text-sm">{date.format('h')}</span>
+				<span className="text-[10px] opacity-60 uppercase font-medium">
+					{date.format('A')}
+				</span>
 			</div>
 		)
 	}
@@ -424,6 +436,7 @@ export function DemoPage() {
 						setTimezone={setTimezone}
 						setUseCustomClasses={setUseCustomClasses}
 						setUseCustomEventRenderer={setUseCustomEventRenderer}
+						setUseCustomHourRenderer={setUseCustomHourRenderer}
 						setUseCustomOnDateClick={setUseCustomOnDateClick}
 						setUseCustomOnEventClick={setUseCustomOnEventClick}
 						setUseCustomTimeIndicator={setUseCustomTimeIndicator}
@@ -433,6 +446,7 @@ export function DemoPage() {
 						useCustomClasses={useCustomClasses}
 						// Resource calendar specific props
 						useCustomEventRenderer={useCustomEventRenderer}
+						useCustomHourRenderer={useCustomHourRenderer}
 						useCustomOnDateClick={useCustomOnDateClick}
 						useCustomOnEventClick={useCustomOnEventClick}
 						useCustomTimeIndicator={useCustomTimeIndicator}
@@ -518,6 +532,7 @@ export function DemoPage() {
 											: undefined
 									}
 									renderEvent={useCustomEventRenderer ? renderEvent : undefined}
+									renderHour={useCustomHourRenderer ? renderHour : undefined}
 									stickyViewHeader={stickyViewHeader}
 									timeFormat={timeFormat}
 									timezone={timezone}
@@ -562,6 +577,7 @@ export function DemoPage() {
 											: undefined
 									}
 									renderEvent={useCustomEventRenderer ? renderEvent : undefined}
+									renderHour={useCustomHourRenderer ? renderHour : undefined}
 									resources={demoResources}
 									stickyViewHeader={stickyViewHeader}
 									timeFormat={timeFormat}

--- a/src/components/hour-label/hour-label.tsx
+++ b/src/components/hour-label/hour-label.tsx
@@ -1,0 +1,16 @@
+import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
+import type { Dayjs } from '@/lib/configs/dayjs-config'
+
+interface HourLabelProps {
+	date: Dayjs
+}
+
+export const HourLabel: React.FC<HourLabelProps> = ({ date }) => {
+	const { renderHour, timeFormat } = useSmartCalendarContext()
+
+	if (renderHour) {
+		return <>{renderHour(date)}</>
+	}
+
+	return <>{date.format(timeFormat === '12-hour' ? 'h A' : 'H')}</>
+}

--- a/src/features/calendar/components/day-view/day-view.test.tsx
+++ b/src/features/calendar/components/day-view/day-view.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import type { CalendarEvent } from '@/components/types'
 import { CalendarProvider } from '@/features/calendar/contexts/calendar-context/provider'
 import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
-import dayjs from '@/lib/configs/dayjs-config'
+import dayjs, { type Dayjs } from '@/lib/configs/dayjs-config'
 import { generateMockEvents } from '@/lib/utils/generator'
 import { DayView } from './day-view'
 
@@ -860,5 +860,29 @@ describe('DayView', () => {
 		// Event starting at 1pm (4 hours into 8-hour grid) should be at 50%
 		const style = eventWrapper?.getAttribute('style') || ''
 		expect(style).toContain('top: 50%')
+	})
+
+	test('customizes hour rendering when renderHour prop is provided', () => {
+		cleanup()
+		const renderHour = (date: Dayjs) => (
+			<span data-testid={`custom-hour-${date.format('HH')}`}>
+				{date.format('HH:mm')}
+			</span>
+		)
+
+		renderDayView({ renderHour })
+
+		// Check that the custom rendering is used
+		const customMidnight = screen.getByTestId('custom-hour-00')
+		expect(customMidnight).toBeInTheDocument()
+		expect(customMidnight).toHaveTextContent('00:00')
+
+		const customNoon = screen.getByTestId('custom-hour-12')
+		expect(customNoon).toBeInTheDocument()
+		expect(customNoon).toHaveTextContent('12:00')
+
+		const customLastHour = screen.getByTestId('custom-hour-23')
+		expect(customLastHour).toBeInTheDocument()
+		expect(customLastHour).toHaveTextContent('23:00')
 	})
 })

--- a/src/features/calendar/components/day-view/day-view.tsx
+++ b/src/features/calendar/components/day-view/day-view.tsx
@@ -1,5 +1,6 @@
 import { AllDayRow } from '@/components/all-day-row/all-day-row'
 import { AnimatedSection } from '@/components/animations/animated-section'
+import { HourLabel } from '@/components/hour-label/hour-label'
 import { VerticalGrid } from '@/components/vertical-grid/vertical-grid'
 import { getViewHours } from '@/features/calendar/utils/view-hours'
 import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
@@ -7,7 +8,7 @@ import dayjs, { type Dayjs } from '@/lib/configs/dayjs-config'
 import { cn } from '@/lib/utils'
 
 export const DayView = () => {
-	const { currentDate, timeFormat, t, businessHours, hideNonBusinessHours } =
+	const { currentDate, t, businessHours, hideNonBusinessHours } =
 		useSmartCalendarContext()
 	const isToday = currentDate.isSame(dayjs(), 'day')
 	const hours = getViewHours({
@@ -27,7 +28,7 @@ export const DayView = () => {
 		noEvents: true,
 		renderCell: (date: Dayjs) => (
 			<div className="text-muted-foreground p-2 text-right text-[10px] sm:text-xs flex flex-col items-center">
-				{date.format(timeFormat === '12-hour' ? 'h A' : 'H')}
+				<HourLabel date={date} />
 			</div>
 		),
 	}

--- a/src/features/calendar/components/week-view/week-view.test.tsx
+++ b/src/features/calendar/components/week-view/week-view.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import type { CalendarEvent } from '@/components/types'
 import { CalendarProvider } from '@/features/calendar/contexts/calendar-context/provider'
 import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
-import dayjs from '@/lib/configs/dayjs-config'
+import dayjs, { type Dayjs } from '@/lib/configs/dayjs-config'
 import { generateMockEvents } from '@/lib/utils/generator'
 import { WeekView } from './week-view'
 
@@ -1024,5 +1024,29 @@ describe('WeekView', () => {
 		// Event starting at 1pm (4 hours into 8-hour grid) should be at 50%
 		const style = eventWrapper?.getAttribute('style') || ''
 		expect(style).toContain('top: 50%')
+	})
+
+	test('customizes hour rendering when renderHour prop is provided', () => {
+		cleanup()
+		const renderHour = (date: Dayjs) => (
+			<span data-testid={`custom-hour-${date.format('HH')}`}>
+				{date.format('HH:mm')}
+			</span>
+		)
+
+		renderWeekView({ renderHour })
+
+		// Check that the custom rendering is used
+		const customMidnights = screen.getAllByTestId('custom-hour-00')
+		expect(customMidnights.length).toBe(1) // In WeekView, it's only in the time column
+		expect(customMidnights[0]).toHaveTextContent('00:00')
+
+		const customNoons = screen.getAllByTestId('custom-hour-12')
+		expect(customNoons.length).toBe(1)
+		expect(customNoons[0]).toHaveTextContent('12:00')
+
+		const customLastHours = screen.getAllByTestId('custom-hour-23')
+		expect(customLastHours.length).toBe(1)
+		expect(customLastHours[0]).toHaveTextContent('23:00')
 	})
 })

--- a/src/features/calendar/components/week-view/week-view.tsx
+++ b/src/features/calendar/components/week-view/week-view.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import { useMemo } from 'react'
 import { AllDayRow } from '@/components/all-day-row/all-day-row'
 import { AnimatedSection } from '@/components/animations/animated-section'
+import { HourLabel } from '@/components/hour-label/hour-label'
 import { VerticalGrid } from '@/components/vertical-grid/vertical-grid'
 import { getViewHours } from '@/features/calendar/utils/view-hours'
 import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
@@ -20,7 +21,6 @@ export const WeekView: React.FC = () => {
 		firstDayOfWeek,
 		selectDate,
 		openEventForm,
-		timeFormat,
 		businessHours,
 		hideNonBusinessHours,
 		hiddenDays,
@@ -59,7 +59,7 @@ export const WeekView: React.FC = () => {
 		noEvents: true,
 		renderCell: (date: Dayjs) => (
 			<div className="text-muted-foreground p-2 text-right text-[10px] sm:text-xs flex flex-col items-center">
-				{date.format(timeFormat === '12-hour' ? 'h A' : 'H')}
+				<HourLabel date={date} />
 			</div>
 		),
 	}

--- a/src/features/calendar/contexts/calendar-context/context.ts
+++ b/src/features/calendar/contexts/calendar-context/context.ts
@@ -64,6 +64,7 @@ export interface CalendarContextType {
 	renderCurrentTimeIndicator?: (
 		props: RenderCurrentTimeIndicatorProps
 	) => React.ReactNode
+	renderHour?: (date: Dayjs) => React.ReactNode
 	hideNonBusinessHours?: boolean
 	hiddenDays?: Set<number>
 }

--- a/src/features/calendar/contexts/calendar-context/provider.tsx
+++ b/src/features/calendar/contexts/calendar-context/provider.tsx
@@ -51,6 +51,7 @@ export interface CalendarProviderProps {
 	renderCurrentTimeIndicator?: (
 		props: RenderCurrentTimeIndicatorProps
 	) => ReactNode
+	renderHour?: (date: Dayjs) => ReactNode
 	hideNonBusinessHours?: boolean
 	hiddenDays?: Set<number>
 }
@@ -87,6 +88,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 	timeFormat = '12-hour',
 	classesOverride,
 	renderCurrentTimeIndicator,
+	renderHour,
 	hideNonBusinessHours = false,
 	hiddenDays,
 }) => {
@@ -193,6 +195,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 			timeFormat,
 			classesOverride,
 			renderCurrentTimeIndicator,
+			renderHour,
 			hideNonBusinessHours,
 			hiddenDays,
 		}),
@@ -217,6 +220,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 			timeFormat,
 			classesOverride,
 			renderCurrentTimeIndicator,
+			renderHour,
 			hideNonBusinessHours,
 			hiddenDays,
 		]

--- a/src/features/calendar/types/index.ts
+++ b/src/features/calendar/types/index.ts
@@ -272,4 +272,9 @@ export interface IlamyCalendarProps {
 	 * @example ['saturday', 'sunday'] // Hide weekends
 	 */
 	hiddenDays?: WeekDays[]
+	/**
+	 * Custom render function for the hour labels in the gutter/header.
+	 * Receives a Dayjs object for the hour and should return a React node.
+	 */
+	renderHour?: (date: Dayjs) => React.ReactNode
 }

--- a/src/features/resource-calendar/components/day-view/resource-day-horizontal.tsx
+++ b/src/features/resource-calendar/components/day-view/resource-day-horizontal.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import { AnimatedSection } from '@/components/animations/animated-section'
+import { HourLabel } from '@/components/hour-label/hour-label'
 import type { BusinessHours } from '@/components/types'
 import { getViewHours } from '@/features/calendar/utils/view-hours'
 import { ResourceEventGrid } from '@/features/resource-calendar/components/resource-event-grid'
@@ -11,15 +12,11 @@ export const ResourceDayHorizontal: React.FC = () => {
 	const {
 		currentDate,
 		t,
-		timeFormat,
 		businessHours,
 		hideNonBusinessHours,
 		getVisibleResources,
 	} = useSmartCalendarContext()
-
 	const resources = getVisibleResources()
-
-	// Generate time columns (hourly slots)
 	const dayHours = getViewHours({
 		referenceDate: currentDate,
 		businessHours,
@@ -62,7 +59,7 @@ export const ResourceDayHorizontal: React.FC = () => {
 								key={`${key}-animated`}
 								transitionKey={`${key}-motion`}
 							>
-								{col.format(timeFormat === '12-hour' ? 'h A' : 'H')}
+								<HourLabel date={col} />
 							</AnimatedSection>
 						)
 					})}

--- a/src/features/resource-calendar/components/day-view/resource-day-vertical.test.tsx
+++ b/src/features/resource-calendar/components/day-view/resource-day-vertical.test.tsx
@@ -4,7 +4,7 @@ import { CalendarDndContext } from '@/components/drag-and-drop/calendar-dnd-cont
 import type { CalendarEvent } from '@/components/types'
 import { ResourceCalendarProvider } from '@/features/resource-calendar/contexts/resource-calendar-context'
 import type { Resource } from '@/features/resource-calendar/types'
-import dayjs from '@/lib/configs/dayjs-config'
+import dayjs, { type Dayjs } from '@/lib/configs/dayjs-config'
 import { ResourceDayVertical } from './resource-day-vertical'
 
 const mockResources: Resource[] = [
@@ -266,5 +266,29 @@ describe('ResourceDayVertical', () => {
 		// Event starting at 1pm (4 hours into 8-hour grid) should be at 50%
 		const style = eventWrapper?.getAttribute('style') || ''
 		expect(style).toContain('top: 50%')
+	})
+
+	test('customizes hour rendering when renderHour prop is provided', () => {
+		cleanup()
+		const renderHour = (date: Dayjs) => (
+			<span data-testid={`custom-hour-${date.format('HH')}`}>
+				{date.format('HH:mm')}
+			</span>
+		)
+
+		renderResourceDayVertical({ renderHour })
+
+		// Check that the custom rendering is used
+		const customMidnight = screen.getByTestId('custom-hour-00')
+		expect(customMidnight).toBeInTheDocument()
+		expect(customMidnight).toHaveTextContent('00:00')
+
+		const customNoon = screen.getByTestId('custom-hour-12')
+		expect(customNoon).toBeInTheDocument()
+		expect(customNoon).toHaveTextContent('12:00')
+
+		const customLastHour = screen.getByTestId('custom-hour-23')
+		expect(customLastHour).toBeInTheDocument()
+		expect(customLastHour).toHaveTextContent('23:00')
 	})
 })

--- a/src/features/resource-calendar/components/day-view/resource-day-vertical.tsx
+++ b/src/features/resource-calendar/components/day-view/resource-day-vertical.tsx
@@ -1,5 +1,6 @@
 import { AllDayCell } from '@/components/all-day-row/all-day-cell'
 import { AllDayRow } from '@/components/all-day-row/all-day-row'
+import { HourLabel } from '@/components/hour-label/hour-label'
 import { ResourceCell } from '@/components/resource-cell'
 import type { BusinessHours } from '@/components/types'
 import { VerticalGrid } from '@/components/vertical-grid/vertical-grid'
@@ -11,7 +12,6 @@ export const ResourceDayVertical: React.FC = () => {
 	const {
 		currentDate,
 		getVisibleResources,
-		timeFormat,
 		businessHours,
 		hideNonBusinessHours,
 	} = useSmartCalendarContext()
@@ -37,7 +37,7 @@ export const ResourceDayVertical: React.FC = () => {
 		noEvents: true,
 		renderCell: (date: Dayjs) => (
 			<div className="text-muted-foreground p-2 text-right text-[10px] sm:text-xs flex flex-col items-center">
-				{date.format(timeFormat === '12-hour' ? 'h A' : 'H')}
+				<HourLabel date={date} />
 			</div>
 		),
 	}

--- a/src/features/resource-calendar/components/week-view/resource-week-horizontal.tsx
+++ b/src/features/resource-calendar/components/week-view/resource-week-horizontal.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useMemo } from 'react'
 import { AnimatedSection } from '@/components/animations/animated-section'
+import { HourLabel } from '@/components/hour-label/hour-label'
 import type { BusinessHours } from '@/components/types'
 import { getViewHours } from '@/features/calendar/utils/view-hours'
 import { ResourceEventGrid } from '@/features/resource-calendar/components/resource-event-grid'
@@ -14,7 +15,6 @@ export const ResourceWeekHorizontal: React.FC = () => {
 		currentDate,
 		firstDayOfWeek,
 		t,
-		timeFormat,
 		businessHours,
 		hideNonBusinessHours,
 		getVisibleResources,
@@ -110,7 +110,7 @@ export const ResourceWeekHorizontal: React.FC = () => {
 								key={`${key}-animated`}
 								transitionKey={`${key}-motion`}
 							>
-								{col.format(timeFormat === '12-hour' ? 'h A' : 'H')}
+								<HourLabel date={col} />
 							</AnimatedSection>
 						)
 					})}

--- a/src/features/resource-calendar/components/week-view/resource-week-vertical.tsx
+++ b/src/features/resource-calendar/components/week-view/resource-week-vertical.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { AllDayCell } from '@/components/all-day-row/all-day-cell'
 import { AllDayRow } from '@/components/all-day-row/all-day-row'
 import { AnimatedSection } from '@/components/animations/animated-section'
+import { HourLabel } from '@/components/hour-label/hour-label'
 import { ResourceCell } from '@/components/resource-cell'
 import type { BusinessHours } from '@/components/types'
 import { VerticalGrid } from '@/components/vertical-grid/vertical-grid'
@@ -17,7 +18,6 @@ export const ResourceWeekVertical: React.FC = () => {
 		currentDate,
 		getVisibleResources,
 		firstDayOfWeek,
-		timeFormat,
 		t,
 		businessHours,
 		hideNonBusinessHours,
@@ -64,11 +64,11 @@ export const ResourceWeekVertical: React.FC = () => {
 			noEvents: true,
 			renderCell: (date: Dayjs) => (
 				<div className="text-muted-foreground p-2 text-right text-[10px] sm:text-xs flex flex-col items-center">
-					{date.format(timeFormat === '12-hour' ? 'h A' : 'H')}
+					<HourLabel date={date} />
 				</div>
 			),
 		}),
-		[hours, timeFormat]
+		[hours]
 	)
 
 	const columns = useMemo(

--- a/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
+++ b/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@/features/calendar/types'
 import type { Resource } from '@/features/resource-calendar/types'
 import { useCalendarEngine } from '@/hooks/use-calendar-engine'
+import type { Dayjs } from '@/lib/configs/dayjs-config'
 import { ResourceCalendarContext } from './context'
 
 const getEventResourceIds = (event: CalendarEvent): (string | number)[] => {
@@ -30,6 +31,7 @@ interface ResourceCalendarProviderProps extends CalendarProviderProps {
 	renderCurrentTimeIndicator?: (
 		props: RenderCurrentTimeIndicatorProps
 	) => React.ReactNode
+	renderHour?: (date: Dayjs) => React.ReactNode
 	hideNonBusinessHours?: boolean
 }
 
@@ -70,6 +72,7 @@ export const ResourceCalendarProvider: React.FC<
 	classesOverride,
 	orientation = 'horizontal',
 	renderCurrentTimeIndicator,
+	renderHour,
 	hideNonBusinessHours = false,
 	hiddenDays,
 }) => {
@@ -280,6 +283,7 @@ export const ResourceCalendarProvider: React.FC<
 			classesOverride,
 			orientation,
 			renderCurrentTimeIndicator,
+			renderHour,
 			hideNonBusinessHours,
 			hiddenDays,
 		}),
@@ -318,6 +322,7 @@ export const ResourceCalendarProvider: React.FC<
 			classesOverride,
 			orientation,
 			renderCurrentTimeIndicator,
+			renderHour,
 			hideNonBusinessHours,
 			hiddenDays,
 		]


### PR DESCRIPTION
This PR adds a new `renderHour` prop to `IlamyCalendar` and `IlamyResourceCalendar` to allow custom hour formatting. It also updates the interactive demo with a toggle to showcase this feature.

Closes #107