### PR TITLE
feat: add eventHeight prop for configurable event bar height

### DIFF
--- a/docs/logs/2026-04-12.md
+++ b/docs/logs/2026-04-12.md
@@ -1,0 +1,37 @@
+# Development Log - 2026-04-12
+
+## Changes
+
+- **[feat]**: Added `eventHeight` prop to control the height of event bars in month view.
+  - Addresses GitHub issue #114: users can now show multi-line content (e.g., title + time) by increasing event bar height.
+  - Defaults to 24px (`EVENT_BAR_HEIGHT`) for backward compatibility.
+  - Flows through the same path as `eventSpacing`: props → context → position calculations → rendering.
+  - Available on both `IlamyCalendar` and `IlamyResourceCalendar`.
+  - `getPositionedEvents()` accepts new `eventBarHeight` parameter.
+  - `horizontal-grid-events-layer`, `grid-cell`, and `all-events-dialog` all read `eventHeight` from context instead of the hardcoded constant.
+
+- **[demo]**: Added `eventHeight` setting to the demo page with options: 20px (compact), 24px (default), 36px, 48px (two lines).
+
+## Files Modified
+
+- `src/components/demo/demo-page.tsx` - Added `eventHeight` state, passed to both calendars and settings
+- `src/components/demo/demo-calendar-settings.tsx` - Added Event Bar Height select dropdown
+- `src/features/calendar/types/index.ts` - Added `eventHeight` to `IlamyCalendarProps`
+- `src/features/calendar/contexts/calendar-context/context.ts` - Added `eventHeight` to `CalendarContextType`
+- `src/features/calendar/contexts/calendar-context/provider.tsx` - Accept and pass through `eventHeight`
+- `src/features/calendar/components/ilamy-calendar.tsx` - Accept `eventHeight`, default to `EVENT_BAR_HEIGHT`
+- `src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx` - Accept and pass through `eventHeight`
+- `src/features/resource-calendar/components/ilamy-resource-calendar/ilamy-resource-calendar.tsx` - Accept `eventHeight`, default to `EVENT_BAR_HEIGHT`
+- `src/lib/utils/position-week-events.ts` - Added `eventBarHeight` param to `getPositionedEvents()`
+- `src/features/calendar/hooks/useProcessedWeekEvents.ts` - Read `eventHeight` from context, pass to positioning
+- `src/components/horizontal-grid/horizontal-grid-events-layer.tsx` - Use `eventHeight` from context
+- `src/components/grid-cell.tsx` - Use `eventHeight` from context for placeholder sizing
+- `src/components/all-events-dialog.tsx` - Use `eventHeight` from context instead of hardcoded `h-[30px]`
+- `src/lib/utils/position-week-events.test.ts` - Added 5 tests for custom `eventBarHeight`
+- `src/components/grid-cell-spacing.test.tsx` - Added test for custom `eventHeight` placeholder sizing
+
+## Notes
+
+- The `eventHeight` prop affects all horizontal grid views: month view, resource month, and resource week horizontal. Week/day views use percentage-based positioning that scales with event duration and are unaffected.
+- Resource calendar inherits `eventHeight` via `IlamyCalendarProps` extension.
+- 732 tests passing, 0 failures. Type check and lint clean.

--- a/src/components/all-events-dialog.tsx
+++ b/src/components/all-events-dialog.tsx
@@ -27,7 +27,7 @@ export const AllEventDialog: React.FC<AllEventDialogProps> = ({ ref }) => {
 	const [dialogOpen, setDialogOpen] = useState(false)
 	const [selectedDayEvents, setSelectedDayEvents] =
 		useState<SelectedDayEvents | null>(null)
-	const { currentDate, firstDayOfWeek } = useSmartCalendarContext()
+	const { currentDate, firstDayOfWeek, eventHeight } = useSmartCalendarContext()
 
 	useImperativeHandle(ref, () => ({
 		open: () => setDialogOpen(true),
@@ -58,10 +58,11 @@ export const AllEventDialog: React.FC<AllEventDialogProps> = ({ ref }) => {
 					{selectedDayEvents?.events.map((event) => {
 						return (
 							<DraggableEvent
-								className="relative my-1 h-[30px]" // Use event ID for unique identification
+								className="relative my-1" // Use event ID for unique identification
 								elementId={`all-events-dialog-event-$${event.id}`}
 								event={event}
 								key={event.id}
+								style={{ height: `${eventHeight}px` }}
 							/>
 						)
 					})}

--- a/src/components/demo/demo-calendar-settings.tsx
+++ b/src/components/demo/demo-calendar-settings.tsx
@@ -60,6 +60,8 @@ interface DemoCalendarSettingsProps {
 	setCalendarHeight: (value: string) => void
 	dayMaxEvents: number
 	setDayMaxEvents: (value: number) => void
+	eventHeight: number
+	setEventHeight: (value: number) => void
 	stickyViewHeader?: boolean
 	setStickyHeader?: (value: boolean) => void
 	timeFormat: TimeFormat
@@ -115,6 +117,8 @@ export function DemoCalendarSettings({
 	setCalendarHeight,
 	dayMaxEvents,
 	setDayMaxEvents,
+	eventHeight,
+	setEventHeight,
 	stickyViewHeader,
 	setStickyHeader,
 	timeFormat,
@@ -384,6 +388,27 @@ export function DemoCalendarSettings({
 							<SelectItem value="4">4 events</SelectItem>
 							<SelectItem value="5">5 events</SelectItem>
 							<SelectItem value="999">No limit</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+				<div>
+					<label className="block text-sm text-left font-medium mb-1">
+						Event Bar Height
+					</label>
+					<Select
+						onValueChange={(value) =>
+							setEventHeight(Number.parseInt(value, 10))
+						}
+						value={eventHeight.toString()}
+					>
+						<SelectTrigger className="w-full">
+							<SelectValue placeholder="Select event height" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="20">20px (compact)</SelectItem>
+							<SelectItem value="24">24px (default)</SelectItem>
+							<SelectItem value="36">36px</SelectItem>
+							<SelectItem value="48">48px (two lines)</SelectItem>
 						</SelectContent>
 					</Select>
 				</div>

--- a/src/components/demo/demo-page.tsx
+++ b/src/components/demo/demo-page.tsx
@@ -313,6 +313,7 @@ export function DemoPage() {
 	const [useCustomTimeIndicator, setUseCustomTimeIndicator] = useState(false)
 	const [useCustomHourRenderer, setUseCustomHourRenderer] = useState(false)
 	const [hiddenDays, setHiddenDays] = useState<WeekDays[]>([])
+	const [eventHeight, setEventHeight] = useState(24)
 
 	// Resource calendar settings
 	const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>(
@@ -321,25 +322,40 @@ export function DemoPage() {
 
 	const calendarKey = `${locale}-${initialView}-${initialDate?.toISOString() || 'today'}-${timeFormat}-${useCustomTimeIndicator}`
 
-	// Custom event renderer function
+	// Custom event renderer function — adapts to eventHeight
 	const renderEvent = (event: CalendarEvent) => {
 		const backgroundColor = event.backgroundColor || 'bg-blue-500'
 		const color = event.color || 'text-blue-800'
+		const isCompact = eventHeight <= 24
+		const isLarge = eventHeight >= 36
+
 		return (
 			<div
 				className={cn(
-					'border-primary border-1 border-l-2 px-2 w-full h-full overflow-clip',
+					'border-primary border border-l-2 px-2 w-full h-full overflow-clip',
 					backgroundColor,
 					color
 				)}
 				style={{ backgroundColor, color }}
 			>
-				<p className="text-[10px] font-semibold truncate leading-tight">
+				<p
+					className={cn(
+						'font-semibold truncate leading-tight',
+						isLarge ? 'text-xs' : 'text-[10px]'
+					)}
+				>
 					{event.title}
 				</p>
-				<p className="text-[8px] truncate opacity-80 leading-tight">
-					{event.start.format('h:mm A')} - {event.end.format('h:mm A')}
-				</p>
+				{!isCompact && (
+					<p
+						className={cn(
+							'truncate opacity-80 leading-tight',
+							isLarge ? 'text-[10px]' : 'text-[8px]'
+						)}
+					>
+						{event.start.format('h:mm A')} - {event.end.format('h:mm A')}
+					</p>
+				)}
 			</div>
 		)
 	}
@@ -413,6 +429,7 @@ export function DemoPage() {
 						disableCellClick={disableCellClick}
 						disableDragAndDrop={disableDragAndDrop}
 						disableEventClick={disableEventClick}
+						eventHeight={eventHeight}
 						firstDayOfWeek={firstDayOfWeek}
 						hiddenDays={hiddenDays}
 						hideNonBusinessHours={hideNonBusinessHours}
@@ -429,6 +446,7 @@ export function DemoPage() {
 						setDisableCellClick={setDisableCellClick}
 						setDisableDragAndDrop={setDisableDragAndDrop}
 						setDisableEventClick={setDisableEventClick}
+						setEventHeight={setEventHeight}
 						setFirstDayOfWeek={setFirstDayOfWeek}
 						setHiddenDays={setHiddenDays}
 						setHideNonBusinessHours={setHideNonBusinessHours}
@@ -513,6 +531,7 @@ export function DemoPage() {
 									disableCellClick={disableCellClick}
 									disableDragAndDrop={disableDragAndDrop}
 									disableEventClick={disableEventClick}
+									eventHeight={eventHeight}
 									events={customEvents}
 									firstDayOfWeek={firstDayOfWeek}
 									hiddenDays={hiddenDays}
@@ -557,6 +576,7 @@ export function DemoPage() {
 									disableCellClick={disableCellClick}
 									disableDragAndDrop={disableDragAndDrop} // No year view for resource calendar
 									disableEventClick={disableEventClick}
+									eventHeight={eventHeight}
 									events={resourceEvents}
 									firstDayOfWeek={firstDayOfWeek}
 									hiddenDays={hiddenDays}

--- a/src/components/grid-cell-spacing.test.tsx
+++ b/src/components/grid-cell-spacing.test.tsx
@@ -56,6 +56,25 @@ describe('GridCell Event Spacing', () => {
 		expect(placeholders[0].style.height).toBe(`${EVENT_BAR_HEIGHT}px`)
 		expect(placeholders[1].style.height).toBe(`${EVENT_BAR_HEIGHT}px`)
 	})
+
+	test('event placeholders should use custom eventHeight when provided', () => {
+		const customHeight = 48
+		render(
+			<CalendarProvider
+				dayMaxEvents={3}
+				eventHeight={customHeight}
+				events={mockEvents}
+				initialDate={initialDate}
+			>
+				<GridCell day={initialDate} shouldRenderEvents={true} />
+			</CalendarProvider>
+		)
+		const placeholders = screen.queryAllByTestId(/Event/i)
+
+		expect(placeholders.length).toBe(2)
+		expect(placeholders[0].style.height).toBe(`${customHeight}px`)
+		expect(placeholders[1].style.height).toBe(`${customHeight}px`)
+	})
 })
 
 describe('GridCell droppable ID uniqueness', () => {

--- a/src/components/grid-cell.tsx
+++ b/src/components/grid-cell.tsx
@@ -4,7 +4,6 @@ import type { CalendarEvent } from '@/components/types'
 import { isBusinessHour } from '@/features/calendar/utils/business-hours'
 import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
 import type { Dayjs } from '@/lib/configs/dayjs-config'
-import { EVENT_BAR_HEIGHT } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import type { SelectedDayEvents } from './all-events-dialog'
 import { AllEventDialog } from './all-events-dialog'
@@ -54,6 +53,7 @@ const NoMemoGridCell: React.FC<GridProps> = ({
 		businessHours,
 		currentLocale,
 		eventSpacing,
+		eventHeight,
 		getResourceById,
 	} = useSmartCalendarContext()
 
@@ -169,7 +169,7 @@ const NoMemoGridCell: React.FC<GridProps> = ({
 									className="w-full shrink-0"
 									data-testid={event?.title}
 									key={`empty-${rowIndex}-${event.id}`}
-									style={{ height: `${EVENT_BAR_HEIGHT}px` }}
+									style={{ height: `${eventHeight}px` }}
 								/>
 							))}
 

--- a/src/components/horizontal-grid/horizontal-grid-events-layer.tsx
+++ b/src/components/horizontal-grid/horizontal-grid-events-layer.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { DraggableEvent } from '@/components/draggable-event/draggable-event'
+import { useSmartCalendarContext } from '@/hooks/use-smart-calendar-context'
 import type { Dayjs } from '@/lib/configs/dayjs-config'
-import { EVENT_BAR_HEIGHT } from '@/lib/constants'
 import type { PositionedEvent } from '@/lib/utils/position-week-events'
 
 export interface HorizontalGridEventsLayerProps {
@@ -14,6 +14,7 @@ export interface HorizontalGridEventsLayerProps {
 const NoMemoHorizontalGridEventsLayer: React.FC<
 	HorizontalGridEventsLayerProps
 > = ({ days, resourceId, 'data-testid': dataTestId, positionedEvents }) => {
+	const { eventHeight } = useSmartCalendarContext()
 	const weekStart = days.at(0)?.startOf('day')
 
 	return (
@@ -36,7 +37,7 @@ const NoMemoHorizontalGridEventsLayer: React.FC<
 							left: `calc(${event.left}% + var(--spacing) * 0.25)`,
 							width: `calc(${event.width}% - var(--spacing) * 1)`,
 							top: `${event.top}px`,
-							height: `${EVENT_BAR_HEIGHT}px`,
+							height: `${eventHeight}px`,
 						}}
 					>
 						<DraggableEvent

--- a/src/features/calendar/components/ilamy-calendar.tsx
+++ b/src/features/calendar/components/ilamy-calendar.tsx
@@ -19,6 +19,7 @@ import type {
 } from '@/features/calendar/types'
 import {
 	DAY_MAX_EVENTS_DEFAULT,
+	EVENT_BAR_HEIGHT,
 	GAP_BETWEEN_ELEMENTS,
 	WEEK_DAYS_NUMBER_MAP,
 } from '@/lib/constants'
@@ -66,6 +67,7 @@ export const IlamyCalendar: React.FC<IlamyCalendarProps> = ({
 	initialDate,
 	dayMaxEvents = DAY_MAX_EVENTS_DEFAULT,
 	eventSpacing = GAP_BETWEEN_ELEMENTS,
+	eventHeight = EVENT_BAR_HEIGHT,
 	stickyViewHeader = true,
 	viewHeaderClassName = '',
 	timeFormat = '12-hour',
@@ -76,6 +78,7 @@ export const IlamyCalendar: React.FC<IlamyCalendarProps> = ({
 	return (
 		<CalendarProvider
 			dayMaxEvents={dayMaxEvents}
+			eventHeight={eventHeight}
 			eventSpacing={eventSpacing}
 			events={normalizeEvents<IlamyCalendarPropEvent, CalendarEvent>(events)}
 			firstDayOfWeek={WEEK_DAYS_NUMBER_MAP[firstDayOfWeek]}

--- a/src/features/calendar/contexts/calendar-context/context.ts
+++ b/src/features/calendar/contexts/calendar-context/context.ts
@@ -51,6 +51,7 @@ export interface CalendarContextType {
 	disableDragAndDrop?: boolean
 	dayMaxEvents: number
 	eventSpacing: number
+	eventHeight: number
 	stickyViewHeader: boolean
 	viewHeaderClassName: string
 	headerComponent?: React.ReactNode // Optional custom header component

--- a/src/features/calendar/contexts/calendar-context/provider.tsx
+++ b/src/features/calendar/contexts/calendar-context/provider.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@/features/calendar/types'
 import { useCalendarEngine } from '@/hooks/use-calendar-engine'
 import type { Dayjs } from '@/lib/configs/dayjs-config'
-import { GAP_BETWEEN_ELEMENTS } from '@/lib/constants'
+import { EVENT_BAR_HEIGHT, GAP_BETWEEN_ELEMENTS } from '@/lib/constants'
 import type { Translations, TranslatorFunction } from '@/lib/translations/types'
 import type { CalendarView, TimeFormat } from '@/types'
 import { CalendarContext } from './context'
@@ -37,6 +37,7 @@ export interface CalendarProviderProps {
 	disableDragAndDrop?: boolean
 	dayMaxEvents: number
 	eventSpacing?: number
+	eventHeight?: number
 	stickyViewHeader?: boolean
 	viewHeaderClassName?: string
 	headerComponent?: ReactNode // Optional custom header component
@@ -77,6 +78,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 	disableDragAndDrop,
 	dayMaxEvents,
 	eventSpacing = GAP_BETWEEN_ELEMENTS,
+	eventHeight = EVENT_BAR_HEIGHT,
 	stickyViewHeader = true,
 	viewHeaderClassName = '',
 	headerComponent,
@@ -185,6 +187,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 			disableDragAndDrop,
 			dayMaxEvents,
 			eventSpacing,
+			eventHeight,
 			stickyViewHeader,
 			viewHeaderClassName,
 			headerComponent,
@@ -211,6 +214,7 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({
 			disableDragAndDrop,
 			dayMaxEvents,
 			eventSpacing,
+			eventHeight,
 			stickyViewHeader,
 			viewHeaderClassName,
 			headerComponent,

--- a/src/features/calendar/hooks/useProcessedWeekEvents.ts
+++ b/src/features/calendar/hooks/useProcessedWeekEvents.ts
@@ -31,6 +31,7 @@ export const useProcessedWeekEvents = ({
 		getEventsForDateRange,
 		dayMaxEvents,
 		eventSpacing,
+		eventHeight,
 		getEventsForResource,
 	} = useSmartCalendarContext()
 
@@ -89,9 +90,18 @@ export const useProcessedWeekEvents = ({
 			dayMaxEvents,
 			dayNumberHeight,
 			eventSpacing,
+			eventBarHeight: eventHeight,
 			gridType,
 		})
-	}, [days, dayMaxEvents, dayNumberHeight, eventSpacing, events, gridType])
+	}, [
+		days,
+		dayMaxEvents,
+		dayNumberHeight,
+		eventSpacing,
+		eventHeight,
+		events,
+		gridType,
+	])
 
 	return { positionedEvents, dayEventsMap }
 }

--- a/src/features/calendar/types/index.ts
+++ b/src/features/calendar/types/index.ts
@@ -185,6 +185,13 @@ export interface IlamyCalendarProps {
 	 */
 	eventSpacing?: number
 	/**
+	 * Height of event bars in horizontal grid views (month view, resource month, resource week horizontal) in pixels.
+	 * Increase this to show more content per event (e.g., title + time on separate lines).
+	 * Does not affect day/week views, which use percentage-based heights that scale with event duration.
+	 * Defaults to 24 pixels if not specified.
+	 */
+	eventHeight?: number
+	/**
 	 * Whether to stick the view header to the top of the calendar.
 	 * Useful for keeping the header visible while scrolling.
 	 */

--- a/src/features/resource-calendar/components/ilamy-resource-calendar/ilamy-resource-calendar.tsx
+++ b/src/features/resource-calendar/components/ilamy-resource-calendar/ilamy-resource-calendar.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@/features/resource-calendar/types'
 import {
 	DAY_MAX_EVENTS_DEFAULT,
+	EVENT_BAR_HEIGHT,
 	GAP_BETWEEN_ELEMENTS,
 	WEEK_DAYS_NUMBER_MAP,
 } from '@/lib/constants'
@@ -28,6 +29,7 @@ export const IlamyResourceCalendar: React.FC<IlamyResourceCalendarProps> = ({
 	dayMaxEvents = DAY_MAX_EVENTS_DEFAULT,
 	timeFormat = '12-hour',
 	eventSpacing = GAP_BETWEEN_ELEMENTS,
+	eventHeight = EVENT_BAR_HEIGHT,
 	hiddenDays,
 	...props
 }) => {
@@ -35,6 +37,7 @@ export const IlamyResourceCalendar: React.FC<IlamyResourceCalendarProps> = ({
 		<ResourceCalendarProvider
 			dayMaxEvents={dayMaxEvents}
 			disableDragAndDrop={disableDragAndDrop}
+			eventHeight={eventHeight}
 			eventSpacing={eventSpacing}
 			events={normalizeEvents<IlamyResourceCalendarPropEvent, CalendarEvent>(
 				events

--- a/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
+++ b/src/features/resource-calendar/contexts/resource-calendar-context/provider.tsx
@@ -10,6 +10,7 @@ import type {
 import type { Resource } from '@/features/resource-calendar/types'
 import { useCalendarEngine } from '@/hooks/use-calendar-engine'
 import type { Dayjs } from '@/lib/configs/dayjs-config'
+import { EVENT_BAR_HEIGHT } from '@/lib/constants'
 import { ResourceCalendarContext } from './context'
 
 const getEventResourceIds = (event: CalendarEvent): (string | number)[] => {
@@ -59,6 +60,7 @@ export const ResourceCalendarProvider: React.FC<
 	disableDragAndDrop,
 	dayMaxEvents,
 	eventSpacing = 1,
+	eventHeight = EVENT_BAR_HEIGHT,
 	stickyViewHeader = true,
 	viewHeaderClassName = '',
 	headerComponent,
@@ -276,6 +278,7 @@ export const ResourceCalendarProvider: React.FC<
 			disableDragAndDrop,
 			dayMaxEvents,
 			eventSpacing,
+			eventHeight,
 			stickyViewHeader,
 			viewHeaderClassName,
 			businessHours,
@@ -313,6 +316,7 @@ export const ResourceCalendarProvider: React.FC<
 			disableDragAndDrop,
 			dayMaxEvents,
 			eventSpacing,
+			eventHeight,
 			stickyViewHeader,
 			viewHeaderClassName,
 			headerComponent,

--- a/src/lib/utils/position-week-events.test.ts
+++ b/src/lib/utils/position-week-events.test.ts
@@ -370,6 +370,108 @@ describe('getPositionedEvents', () => {
 		})
 	})
 
+	describe('Custom Event Bar Height', () => {
+		it('uses custom eventBarHeight in top and height calculation', () => {
+			const customHeight = 40
+
+			const result = getPositionedEvents({
+				days,
+				events: [singleDayEvent],
+				dayMaxEvents: 4,
+				eventBarHeight: customHeight,
+			})
+
+			expect(result).toHaveLength(1)
+			const expectedTop =
+				DAY_NUMBER_HEIGHT +
+				GAP_BETWEEN_ELEMENTS +
+				0 * (customHeight + GAP_BETWEEN_ELEMENTS)
+			expect(result[0].top).toBe(expectedTop)
+			expect(result[0].height).toBe(customHeight)
+		})
+
+		it('uses custom eventBarHeight for stacked events', () => {
+			const customHeight = 48
+
+			const result = getPositionedEvents({
+				days,
+				events: [
+					singleDayEvent,
+					{
+						...singleDayEvent,
+						id: 'single-2',
+						start: dayjs('2025-01-13T12:00:00.000Z'),
+						end: dayjs('2025-01-13T13:00:00.000Z'),
+					},
+				],
+				dayMaxEvents: 4,
+				eventBarHeight: customHeight,
+			})
+
+			expect(result).toHaveLength(2)
+			const firstTop =
+				DAY_NUMBER_HEIGHT +
+				GAP_BETWEEN_ELEMENTS +
+				0 * (customHeight + GAP_BETWEEN_ELEMENTS)
+			const secondTop =
+				DAY_NUMBER_HEIGHT +
+				GAP_BETWEEN_ELEMENTS +
+				1 * (customHeight + GAP_BETWEEN_ELEMENTS)
+			expect(result[0].top).toBe(firstTop)
+			expect(result[0].height).toBe(customHeight)
+			expect(result[1].top).toBe(secondTop)
+			expect(result[1].height).toBe(customHeight)
+		})
+
+		it('uses custom eventBarHeight with custom eventSpacing', () => {
+			const customHeight = 36
+			const customSpacing = 4
+
+			const result = getPositionedEvents({
+				days,
+				events: [singleDayEvent],
+				dayMaxEvents: 4,
+				eventBarHeight: customHeight,
+				eventSpacing: customSpacing,
+			})
+
+			expect(result).toHaveLength(1)
+			const expectedTop =
+				DAY_NUMBER_HEIGHT + customSpacing + 0 * (customHeight + customSpacing)
+			expect(result[0].top).toBe(expectedTop)
+			expect(result[0].height).toBe(customHeight)
+		})
+
+		it('defaults to EVENT_BAR_HEIGHT when eventBarHeight is not provided', () => {
+			const result = getPositionedEvents({
+				days,
+				events: [singleDayEvent],
+				dayMaxEvents: 4,
+			})
+
+			expect(result[0].height).toBe(EVENT_BAR_HEIGHT)
+		})
+
+		it('uses custom eventBarHeight for multi-day events', () => {
+			const customHeight = 32
+
+			const result = getPositionedEvents({
+				days,
+				events: [multiDayEvent],
+				dayMaxEvents: 4,
+				eventBarHeight: customHeight,
+			})
+
+			expect(result).toHaveLength(1)
+			const expectedTop =
+				DAY_NUMBER_HEIGHT +
+				GAP_BETWEEN_ELEMENTS +
+				0 * (customHeight + GAP_BETWEEN_ELEMENTS)
+			expect(result[0].top).toBe(expectedTop)
+			expect(result[0].height).toBe(customHeight)
+		})
+	})
+
 	describe('Custom Event Spacing', () => {
 		it('uses custom eventSpacing in vertical positioning', () => {
 			const customSpacing = 4

--- a/src/lib/utils/position-week-events.ts
+++ b/src/lib/utils/position-week-events.ts
@@ -23,6 +23,7 @@ interface GetPositionedEventsProps {
 	dayNumberHeight?: number
 	gridType?: 'day' | 'hour' // Future use for different grid types
 	eventSpacing?: number // Custom vertical spacing between events (defaults to GAP_BETWEEN_ELEMENTS)
+	eventBarHeight?: number // Custom height for event bars in pixels (defaults to EVENT_BAR_HEIGHT)
 }
 
 export const getPositionedEvents = ({
@@ -32,6 +33,7 @@ export const getPositionedEvents = ({
 	dayNumberHeight = DAY_NUMBER_HEIGHT,
 	gridType = 'day',
 	eventSpacing = GAP_BETWEEN_ELEMENTS,
+	eventBarHeight = EVENT_BAR_HEIGHT,
 }: GetPositionedEventsProps) => {
 	// For hour-based grids, use actual first/last hours from days array
 	// For day-based grids, use start/end of day to capture all events
@@ -121,8 +123,8 @@ export const getPositionedEvents = ({
 				top:
 					dayNumberHeight +
 					eventSpacing +
-					assignedRow * (EVENT_BAR_HEIGHT + eventSpacing),
-				height: EVENT_BAR_HEIGHT,
+					assignedRow * (eventBarHeight + eventSpacing),
+				height: eventBarHeight,
 				position: assignedRow,
 				...event,
 				isTruncatedStart,
@@ -168,8 +170,8 @@ export const getPositionedEvents = ({
 						top:
 							dayNumberHeight +
 							eventSpacing +
-							truncatedAssignedRow * (EVENT_BAR_HEIGHT + eventSpacing),
-						height: EVENT_BAR_HEIGHT,
+							truncatedAssignedRow * (eventBarHeight + eventSpacing),
+						height: eventBarHeight,
 						position: truncatedAssignedRow,
 						...event,
 						isTruncatedStart: true, // Always truncated at start when using this fallback logic
@@ -215,8 +217,8 @@ export const getPositionedEvents = ({
 				top:
 					dayNumberHeight +
 					eventSpacing +
-					assignedRow * (EVENT_BAR_HEIGHT + eventSpacing),
-				height: EVENT_BAR_HEIGHT,
+					assignedRow * (eventBarHeight + eventSpacing),
+				height: eventBarHeight,
 				position: assignedRow,
 				...event,
 				isTruncatedStart,


### PR DESCRIPTION
## Summary

- Adds a new `eventHeight` prop to `IlamyCalendar` and `IlamyResourceCalendar` that controls the height of event bars in horizontal grid views (month, resource month, resource week horizontal)
- Defaults to 24px for full backward compatibility
- Enables users to show multi-line content (e.g., title + booking times on separate lines) by increasing event bar height
- Demo page updated with an "Event Bar Height" setting and an adaptive custom event renderer

Closes #114

## Usage

```tsx
<IlamyCalendar
  eventHeight={48}
  renderEvent={(event) => (
    <div className="h-full w-full bg-blue-500 text-white px-1 rounded-md overflow-clip">
      <p className="text-xs font-semibold">{event.title}</p>
      <p className="text-[10px] opacity-80">
        {event.start.format('h:mm A')} - {event.end.format('h:mm A')}
      </p>
    </div>
  )}
/>
```

## Changes

| Area | Detail |
|------|--------|
| **Props** | `eventHeight?: number` on `IlamyCalendarProps` (inherited by resource calendar) |
| **Position calc** | `getPositionedEvents()` accepts `eventBarHeight` param |
| **Rendering** | `horizontal-grid-events-layer`, `grid-cell`, `all-events-dialog` read from context |
| **Context** | Flows through `CalendarProvider` and `ResourceCalendarProvider` |
| **Demo** | Settings dropdown (20/24/36/48px) + adaptive `renderEvent` |

## Test plan

- [x] 732 tests passing, 0 failures
- [x] TypeScript type check clean
- [x] Lint + prettier clean
- [x] 5 new unit tests for `eventBarHeight` in position calculations
- [x] 1 new integration test for `eventHeight` in GridCell placeholder sizing
- [ ] Verify in browser: month view with eventHeight=48 shows two-line events
- [ ] Verify in browser: resource month/week horizontal views respect eventHeight
- [ ] Verify backward compatibility: default (no prop) renders identically to before