### PR TITLE
fix: evenly distribute quarter-hour gridlines in vertical grid (#119)

### DIFF
--- a/.agents/skills/release-new-version/SKILL.md
+++ b/.agents/skills/release-new-version/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: release-new-version
+description: Cut a new release of @ilamy/calendar — analyze commits since the last tag, suggest a semver bump, draft a CHANGELOG entry in the project's existing style, run the CI gate, commit, tag, push to origin, and create the GitHub release page (marked as `latest`). Stops before `npm publish` so the user can log in interactively. Use whenever the user says "release a new version", "cut a release", "ship v1.x", "bump the version", "prep a release", "publish the next version", or anything that implies a new version should go out — even if they don't mention publish, changelog, or GitHub release.
+---
+
+# Release a new version of @ilamy/calendar
+
+You're shipping a new version of the `@ilamy/calendar` npm package. The flow is conservative on purpose: suggest, wait for approval, apply, wait for approval, push. The user handles `npm publish` manually (it needs an interactive login).
+
+**Why the pauses matter.** Recent git history shows version churn (`1.7.0` → `1.6.1` → `1.6.0` → `1.6.1`) from premature version bumps. Every step that writes to the tree, commits, tags, or pushes should be explicitly approved. It's cheap to pause and expensive to revert a tag.
+
+## Phase 1 — Preflight
+
+Do these in parallel and report anything wrong. Do not proceed if any check fails; tell the user and let them resolve it.
+
+- `git branch --show-current` → must be `main` (releases land on main per recent history).
+- `git status --short` → must be empty. If there are staged/unstaged changes, ask the user whether to commit, stash, or abort.
+- `git fetch origin main` then `git rev-list --left-right --count origin/main...HEAD` → local must be **equal to or 0 ahead** of `origin/main`. If local is behind, pull first. If ahead, confirm with the user that the unpushed commits are intended for this release.
+- `git describe --tags --abbrev=0` → capture the last release tag (e.g., `v1.6.1`). This is the baseline for the commit log and the changelog `compare` link.
+- Read `package.json` `version` field. Sanity-check it matches the last tag minus the `v` prefix. If they diverge (as happened with the `1.7.0` → `1.6.1` revert), surface the mismatch and ask the user what the correct baseline is before continuing.
+
+Do **not** run `bun run ci` yet — save it for Phase 4 so we don't waste a clean build if the user doesn't like the version or the changelog.
+
+## Phase 2 — Suggest a version bump
+
+Goal: propose `patch`, `minor`, or `major` with evidence, and wait for the user's call.
+
+1. `git log <last-tag>..HEAD --pretty=format:"%h %s"` — list every commit since the last tag.
+2. Classify each commit by its conventional prefix:
+   - `feat:` → minor
+   - `fix:` / `perf:` → patch
+   - `refactor:` / `chore:` / `docs:` / `test:` / `style:` → patch (internal-only; doesn't bump minor)
+   - `!:` suffix anywhere, or `BREAKING CHANGE:` in body → major
+3. The suggested bump is the **highest** level across all commits. Example: 5 `fix:` + 1 `feat:` → minor.
+4. Present a short table to the user:
+
+   ```
+   Since v1.6.1 (7 commits):
+     feat (1):  feat: add weekViewGranularity prop (#113)
+     fix  (3):  fix: ..., fix: ..., fix: ...
+     perf (1):  perf: ...
+     chore(2):  chore: ..., chore: ...
+   Suggested bump: minor → v1.7.0
+   ```
+
+5. Ask: *"Bump to v1.7.0 (minor), or different?"*. Wait for approval. If the user picks a different level, use their choice — don't argue.
+
+**Edge cases to call out up front (don't fix silently):**
+- A commit with no conventional prefix: show it to the user and ask how to classify.
+- A `feat:` that looks trivial or a `fix:` that looks like a breaking change: flag it; the user decides.
+- Zero commits since the last tag: stop, tell the user there's nothing to release.
+
+## Phase 3 — Draft the CHANGELOG entry
+
+Match the **existing format** in `CHANGELOG.md` exactly — the repo has a consistent style and downstream tooling/readers expect it.
+
+### Entry template
+
+```markdown
+#### [vX.Y.Z](https://github.com/kcsujeet/ilamy-calendar/compare/vPREV...vX.Y.Z)
+
+> DD Month YYYY
+
+##### Features
+
+- feat: <rewritten, user-facing description> ([`#N`](https://github.com/kcsujeet/ilamy-calendar/pull/N)) — Thanks [@handle](https://github.com/handle)!
+
+##### Fixes
+
+- fix: <rewritten, user-facing description> ([`#N`](https://github.com/kcsujeet/ilamy-calendar/pull/N))
+
+##### Performance
+
+- perf: <description>
+
+##### Internal
+
+- chore: <description>
+```
+
+### Rules
+
+- **Sections, in this order, only if non-empty**: `Features`, `Fixes`, `Performance`, `Internal`. Skip empty sections entirely — don't render an empty `##### Performance` heading.
+- **Section mapping**:
+  - `feat:` → Features
+  - `fix:` → Fixes
+  - `perf:` → Performance
+  - `chore:` / `refactor:` / `docs:` / `test:` / `style:` → Internal (but see "what to include" below)
+- **Date**: today's date in UTC, formatted `D Month YYYY` (e.g., `19 April 2026`). Use `date -u "+%-d %B %Y"` — no leading zero on the day.
+- **Compare link**: `https://github.com/kcsujeet/ilamy-calendar/compare/vPREV...vX.Y.Z`. Always include it, even if `vPREV` doesn't exist yet as a tag on GitHub — it'll render once pushed.
+- **PR link format**: `([`#N`](https://github.com/kcsujeet/ilamy-calendar/pull/N))` — backticks around `#N`, trailing space before the parenthesis group.
+- **Issue-closing**: if a PR body closes an issue, append `— Closes [`#M`](https://github.com/kcsujeet/ilamy-calendar/issues/M)`.
+- **Contributor attribution**: for each PR, run `gh pr view <N> --json author,number`. If the author login is **not** `kcsujeet`, append `— Thanks [@<handle>](https://github.com/<handle>)!`. Don't thank the repo owner.
+- **Bullet wording**: rewrite commit messages into user-facing prose. "feat: add prop X" → "feat: add `X` prop — lets consumers do Y". Read the PR/commit body for the why. Avoid internal jargon the user-facing audience won't parse. When the original commit message is already good, lifting it directly is fine.
+
+### What to include vs. omit
+
+- **Always include**: `feat`, `fix`, `perf` — these affect consumers.
+- **Internal section**: include only things a library user might care about — dep upgrades, bundle-size wins, tooling that changes how contributors work (e.g., "Tailwind upgraded to v4.2.2"). **Omit**: test-only changes, doc-only changes not affecting the public surface, lint tweaks, dev-log updates. When in doubt, leave it out — a short section reads better than a noisy one.
+- **Group duplicates**: if three commits all touch the same feature (e.g., iterating on a fix), consolidate into one bullet that describes the net outcome, with the PR link pointing at the merge PR.
+
+### Present the draft and wait
+
+Insert the new entry at the **top** of `CHANGELOG.md` (after the `### Changelog` preamble, before the previous release). Show the user the full draft entry (not a diff — a diff of a prepend is noisy). Ask: *"Changelog looks right? Any wording changes?"*. Wait for approval. Iterate until they're happy.
+
+## Phase 4 — Run the CI gate
+
+Only now run `bun run ci` (lint + type-check + test + build). If it fails, stop and surface the failure — do not bump the version or commit anything. The user fixes the failure, then re-runs the skill (Phase 1 will re-check state).
+
+## Phase 5 — Apply the bump
+
+In this order:
+
+1. Edit `package.json` to set `"version": "X.Y.Z"`. Don't use `npm version` — its default behavior creates its own commit and tag with a message you don't control, and the recent revert chaos suggests you want full control over the commit.
+2. Write the new changelog entry into `CHANGELOG.md` (already drafted in Phase 3).
+3. Update `docs/logs/YYYY-MM-DD.md` (today, per the project's mandatory dev-log rule) with a one-line summary: "**[release]**: Cut vX.Y.Z — <short summary of what's in it>".
+4. Stage **only** these three files explicitly by name — never `git add -A`:
+   ```
+   git add package.json CHANGELOG.md docs/logs/<today>.md
+   ```
+5. Commit with message exactly `X.Y.Z` (matching the project's existing release-commit style — see commits `1.6.0`, `1.6.1`, `1.7.0` in `git log`). No conventional prefix, no body, no co-author trailer (project CLAUDE.md forbids AI co-author trailers).
+6. Tag: `git tag vX.Y.Z`. Lightweight tag, no `-a -m` — matches existing tag style in this repo unless `git tag -n <last-tag>` shows otherwise, in which case match that.
+
+Show the user `git log -1 --stat` and `git tag --points-at HEAD` and ask: *"Ready to push `main` and tag `vX.Y.Z` to `origin`?"*. Wait for approval.
+
+## Phase 6 — Push
+
+On explicit approval:
+
+```
+git push origin main
+git push origin vX.Y.Z
+```
+
+Two separate pushes. If either fails (e.g., non-fast-forward on `main` because someone pushed while you were drafting), stop immediately — **do not** use `--force`. Tell the user and let them resolve.
+
+## Phase 7 — Create the GitHub release
+
+Turn the pushed tag into a published release page on GitHub, marked as `latest`. This is public-facing, so follow the project's workflow rule: draft the body, get explicit approval, then post.
+
+1. **Extract the release notes** from the changelog. Read the block you just added to `CHANGELOG.md`, starting **after** the `#### [vX.Y.Z](...)` heading (GitHub's title row already renders the version + compare link) and ending **before** the next `#### [v` heading (or EOF). Keep the `> DD Month YYYY` date line and the `##### Features` / `##### Fixes` / etc. sections verbatim.
+2. **Write to a temp file**: `/tmp/release-notes-vX.Y.Z.md`. Don't inline the body as a CLI arg — shell quoting mangles backticks and newlines. A file is lossless.
+3. **Show the body to the user** and ask: *"Post this as the vX.Y.Z release on GitHub and mark it latest?"* Wait for approval. Project rule (`.agents/rules/workflow.md`): never post public-facing content without explicit approval, even if the user has broadly opted-in to this skill.
+4. **On approval**, create the release:
+   ```
+   gh release create vX.Y.Z \
+     --repo kcsujeet/ilamy-calendar \
+     --title "vX.Y.Z" \
+     --notes-file /tmp/release-notes-vX.Y.Z.md \
+     --latest \
+     --verify-tag
+   ```
+   Notes:
+   - `--latest` pins this release as the one GitHub's UI/npm badges/readme install snippets point at. Pass it explicitly — don't rely on `gh`'s auto-latest heuristic, because backport releases (e.g., a 1.5.3 after 1.6.0 exists) would otherwise lose the flag silently.
+   - `--verify-tag` fails loudly if the tag didn't make it to the remote. Better than creating a release pointing at nothing.
+   - No `--draft`. The user already approved the body in step 3; publishing a draft just means they have to click "Publish" again.
+5. **Report the release URL** from `gh`'s output so the user can open it.
+
+## Phase 8 — Hand off to the user
+
+Only one manual step is left:
+
+```
+Released vX.Y.Z. Remaining (manual):
+
+  npm publish --access public
+
+  (needs interactive npm login — that's why this skill stops here)
+```
+
+Do not offer to run `npm publish` yourself — it requires credentials you don't have. That's the only thing the user does by hand.
+
+## Failure modes to watch for
+
+- **Tag already exists** (`git tag vX.Y.Z` fails): somebody already cut this version, or a previous attempt got halfway. Ask the user before using `-f`.
+- **`package.json` version doesn't match latest tag**: the canonical example is the recent `1.7.0` → reverted state. Flag it, ask what the true baseline is.
+- **Unmerged PR references in the changelog**: the user closed a PR by rebasing/squashing. When you run `gh pr view <N>`, confirm the PR is `merged` (not `closed`). If it's `closed` without merging, don't credit it.
+- **`bun run ci` is slow** (~60s+ for the full gate on this repo): run it in the background and keep drafting; don't block the user unnecessarily.

--- a/docs/logs/2026-04-21.md
+++ b/docs/logs/2026-04-21.md
@@ -1,0 +1,21 @@
+# Development Log - 2026-04-21
+
+## Changes
+
+- **[fix][vertical-grid]**: Fixed GitHub issue #119 — quarter-hour dashed gridlines were unevenly distributed in `IlamyResourceCalendar` (orientation=vertical, day view) and also in the regular `IlamyCalendar` day view. Root cause: `VerticalGridCol` had `gridTemplateRows: repeat(days.length, 1fr)` but emitted `days.length × cellSlots.length` **flat** children, so CSS Grid auto-flow scattered the 4 quarters of one hour across explicit + implicit rows. Fix: wrap each hour's `cellSlots.map` output in one `flex flex-col min-h-[60px]` div (one child per grid row), and give each quarter-hour cell `flex-1 min-h-0` instead of the fixed `h-[15px]`. The hour rows now align cleanly with the adjacent hour-label column and quarters subdivide each hour equally.
+- **[fix][vertical-grid]**: Follow-up — wrapping quarters in a per-hour flex div made the 4th quarter a `:last-child`, which triggered `GridCell`'s base `last:border-r-0` (see `src/components/grid-cell.tsx:131`) and created a visible break in the column separator every hour. Solution: move the right border from the individual quarter cells onto the **hour wrapper itself** (one `border-r` per hour, or `border-r-0` on the last column). Each quarter cell now carries `border-r-0` unconditionally, sidestepping the `:last-child` trap entirely. This is cleaner than trying to win the `last:` variant war on the cell.
+- **[test][vertical-grid]**: Added one structural test in `vertical-grid-col.test.tsx` asserting that all 4 quarter-hour cells for a given hour share the same `flex-col` parent wrapper and each carries `flex-1` (without `h-[15px]`).
+- **[demo]**: Temporarily replaced `DemoPage` render with the issue #119 minimal repro to visually confirm the bug + fix on the running dev server. **Reverted before commit** (see Files Modified note below).
+
+## Files Modified
+
+- `src/components/vertical-grid/vertical-grid-col.tsx` - Wrapped `cellSlots.map` output in a `flex flex-col min-h-[60px]` div per hour; quarter cells now use `flex-1 min-h-0 border-dashed` instead of `h-[15px] min-h-[15px]`.
+- `src/components/vertical-grid/vertical-grid-col.test.tsx` - Added `'groups quarter-hour cells under one hour wrapper that shares the row equally'` test.
+- `src/components/demo/demo-page.tsx` - **TEMPORARY** repro injected at top of `DemoPage` return, pending revert before commit. Also added runtime `dayjs` import (previously type-only).
+
+## Notes
+
+- All 817 tests pass, `bun run type-check` clean.
+- Pending before commit: (1) revert `demo-page.tsx` to its pre-session contents, (2) run `bun run lint` + `bun run prettier:check`, (3) request user approval for the commit with prefix `fix: ` (≤100 chars).
+- Plan file: `/Users/sujeetkc1/.claude/plans/make-a-plan-to-fluffy-forest.md`.
+- `VerticalGridEventsLayer` uses absolute positioning with time math (not grid rows), so event placement is unaffected by the wrapping change.

--- a/src/components/vertical-grid/vertical-grid-col.test.tsx
+++ b/src/components/vertical-grid/vertical-grid-col.test.tsx
@@ -92,6 +92,36 @@ describe('VerticalGridCol', () => {
 		).toBeInTheDocument()
 	})
 
+	test('groups quarter-hour cells under one hour wrapper that shares the row equally', () => {
+		const dateStr = initialDate.format('YYYY-MM-DD')
+		renderVerticalGridCol({
+			cellSlots: [0, 15, 30, 45],
+		})
+
+		const nineZero = screen.getByTestId(`vertical-cell-${dateStr}-09-00`)
+		const nineFifteen = screen.getByTestId(`vertical-cell-${dateStr}-09-15`)
+		const nineThirty = screen.getByTestId(`vertical-cell-${dateStr}-09-30`)
+		const nineFortyFive = screen.getByTestId(`vertical-cell-${dateStr}-09-45`)
+
+		// All 4 quarter-hour cells for 09:00 must share the same direct parent
+		// so CSS Grid treats them as one row, not four scattered children.
+		const wrapper = nineZero.parentElement
+		expect(wrapper).not.toBeNull()
+		expect(nineFifteen.parentElement).toBe(wrapper)
+		expect(nineThirty.parentElement).toBe(wrapper)
+		expect(nineFortyFive.parentElement).toBe(wrapper)
+
+		// The wrapper must be a flex column so the 4 cells split the hour evenly.
+		expect(wrapper?.className).toMatch(/\bflex-col\b/)
+
+		// Each quarter-hour cell must use flex-1 (1/N share) and NOT a fixed
+		// h-[15px] that would bunch cells at the bottom of taller rows.
+		for (const cell of [nineZero, nineFifteen, nineThirty, nineFortyFive]) {
+			expect(cell.className).toMatch(/\bflex-1\b/)
+			expect(cell.className).not.toMatch(/\bh-\[15px\]\b/)
+		}
+	})
+
 	test('renders events layer by default', () => {
 		renderVerticalGridCol()
 		expect(screen.getByTestId('vertical-events-test-col')).toBeInTheDocument()

--- a/src/components/vertical-grid/vertical-grid-col.tsx
+++ b/src/components/vertical-grid/vertical-grid-col.tsx
@@ -74,29 +74,39 @@ const NoMemoVerticalGridCol: React.FC<VerticalGridColProps> = ({
 						)
 					}
 
-					return cellSlots.map((minute) => {
-						const m = minute === 60 ? undefined : minute
-						const mm = m === undefined ? '00' : String(m).padStart(2, '0')
-						const testId = keys.cell.vertical(day, hourStr, mm, resourceId)
+					return (
+						<div
+							className={cn(
+								'flex flex-col min-h-[60px]',
+								isLastColumn ? 'border-r-0' : 'border-r'
+							)}
+							key={keys.listKey(id, dayIndex, hourStr)}
+						>
+							{cellSlots.map((minute) => {
+								const m = minute === 60 ? undefined : minute
+								const mm = m === undefined ? '00' : String(m).padStart(2, '0')
+								const testId = keys.cell.vertical(day, hourStr, mm, resourceId)
+								const isQuarter = minute !== 60
 
-						return (
-							<GridCell
-								className={cn(
-									'hover:bg-accent relative z-10 min-h-[60px] cursor-pointer border-b',
-									minute === 60 ? '' : 'border-dashed h-[15px] min-h-[15px]',
-									isLastColumn ? 'border-r-0' : 'border-r'
-								)}
-								data-testid={testId}
-								day={m ? day.minute(m) : day}
-								gridType={gridType}
-								hour={day.hour()}
-								key={keys.listKey(id, dayIndex, mm)}
-								minute={m}
-								resourceId={resourceId} // Events are rendered in a separate layer
-								shouldRenderEvents={false}
-							/>
-						)
-					})
+								return (
+									<GridCell
+										className={cn(
+											'hover:bg-accent relative z-10 flex-1 min-h-0 cursor-pointer border-b border-r-0',
+											isQuarter && 'border-dashed'
+										)}
+										data-testid={testId}
+										day={m ? day.minute(m) : day}
+										gridType={gridType}
+										hour={day.hour()}
+										key={keys.listKey(id, dayIndex, mm)}
+										minute={m}
+										resourceId={resourceId} // Events are rendered in a separate layer
+										shouldRenderEvents={false}
+									/>
+								)
+							})}
+						</div>
+					)
 				})}
 
 				{/* Event blocks layer */}


### PR DESCRIPTION
## Summary

- Fixes [#119](https://github.com/kcsujeet/ilamy-calendar/issues/119): quarter-hour dashed gridlines were bunched at the bottom of each hour row in `IlamyResourceCalendar` (orientation=vertical, day view). Same bug existed in the regular `IlamyCalendar` day view.
- Root cause: `VerticalGridCol` declared `gridTemplateRows: repeat(days.length, 1fr)` but emitted `days.length × cellSlots.length` **flat** children, so CSS Grid auto-flow scattered the 4 quarters of one hour across explicit + implicit rows, and the quarter cells didn't align with the hour-label column.
- Fix: wrap each hour's `cellSlots.map` output in a single `flex flex-col min-h-[60px]` div (one child per grid row). Each quarter-hour cell now uses `flex-1 min-h-0` instead of a fixed `h-[15px]`, so the 4 quarters always subdivide the hour equally at 25/50/75/100%.
- Sub-fix: move the column's right border onto the hour wrapper (`border-r` / `border-r-0` based on `isLastColumn`) and make every quarter cell `border-r-0`. This sidesteps `GridCell`'s base `last:border-r-0` rule, which would otherwise break the column separator at every 4th quarter.

## Test plan

- [x] `bun test` — 817 pass (added new `groups quarter-hour cells under one hour wrapper…` structural test in `vertical-grid-col.test.tsx`)
- [x] `bun run type-check` — clean
- [x] `bun run check` — lint + format clean
- [x] Visually reproduced the bug against the exact repro in #119, confirmed the fix removes both the uneven-gridline issue and the per-hour column-separator break
- [ ] Reviewer: spot-check regular `IlamyCalendar` day view (same `VerticalGrid`/`VerticalGridCol`, so it benefits from the fix too)
- [ ] Reviewer: spot-check drag-to-create on a quarter-hour cell — hover target now covers 1/4 of the hour row as intended