### PR TITLE
fix(resource-week): show day number only in week headers

### DIFF
--- a/docs/logs/2026-05-30.md
+++ b/docs/logs/2026-05-30.md
@@ -7,17 +7,23 @@
 - **[AGENTS.md / hard rules]**: Added an "ALWAYS use the latest published version when adding a dependency" rule (check `npm view`, don't copy versions from examples/memory). Reconciled the existing "NEVER use npm/node/vite/pnpm" rule, which now contradicted the Vite-based dev server — reworded to "npm/node/pnpm as the package manager or runtime" and noted tools run via `bunx` (e.g. `bunx vite`).
 - **[examples / latest versions]**: Bumped all three examples (`vite`, `nextjs`, `astro`) to latest deps. Notable majors: Vite 6→8 + `@vitejs/plugin-react` 4→6 (vite example), Astro 5→6 + `@astrojs/react` 4→5 (astro example), TypeScript 5.9→6, `@types/node` 22→25 (nextjs), `@ilamy/calendar` → ^1.7.0 everywhere. Verified peers (plugin-react 6 ↔ vite 8, @astrojs/react 5 ↔ react 19, next 16 ↔ react 19; Astro 6 engine node ≥22.12, local 23.11). Refreshed each example's `bun.lock` and confirmed all three `bun run build` successfully.
 - **[examples/vite / TS6 fix]**: Added `examples/vite/src/vite-env.d.ts` (`/// <reference types="vite/client" />`). TypeScript 6's stricter side-effect-import checking (TS2882) failed the build on `import './index.css'` because nothing referenced Vite's client type shims (which declare `*.css`). This is the standard Vite scaffolding file that was missing.
+- **[resource week view / date format] (issue #157)**: Resource Week View day headers showed the `M/D` slash format (e.g. `5/19`) while the standard Week View shows only the day number (`19`). Made them consistent by switching the resource week headers to `day.format('D')`. Fixed all three render paths: horizontal day header, vertical hourly day header, and the vertical daily-mode first column.
 
 ## Files Modified
 
 - `vite.config.ts` - New. React + Tailwind v4 plugins, `@` alias → `src/`, `root: 'src'`, dev server on port 4100 with `strictPort`.
 - `package.json` - `dev` script → `bunx vite`; added vite/plugin-react/tailwind-vite devDeps.
 - `bun.lock` - Lockfile updated for new deps.
+- `examples/*/package.json`, `examples/*/bun.lock` - Bumped to latest; added `examples/vite/src/vite-env.d.ts`.
+- `src/features/resource-calendar/components/week-view/horizontal/resource-week-horizontal-day-header.tsx` - `M/D` → `D`
+- `src/features/resource-calendar/components/week-view/vertical/resource-week-vertical-day-header.tsx` - `M/D` → `D`
+- `src/features/resource-calendar/components/week-view/vertical/resource-week-vertical.tsx` - `M/D` → `D` in the daily-mode first column
+- `resource-week-horizontal.test.tsx` / `resource-week-vertical.test.tsx` - Added issue #157 regression tests (no `M/D` slash format in headers); added a daily-mode case; updated the existing daily-mode "week number" test to scope its assertion to the week gutter (the bare day number `1` now collides with week number `1`).
 
 ## Notes
 
-- Production demo serving (`bun run start`) intentionally still uses the Bun path (`src/index.tsx` → `src/index.html` → `frontend.tsx`); only dev was the problem, so it was left untouched. `src/index.tsx`, `src/index.html`, and `src/frontend.tsx` all remain in use by `start`.
+- Production demo serving (`bun run start`) intentionally still uses the Bun path (`src/index.tsx` → `src/index.html` → `frontend.tsx`); only dev was the problem, so it was left untouched.
 - `frontend.tsx`'s `import.meta.hot` HMR block works under Vite as-is (no Bun-specific API).
-- Did not add a `preview` script: with `root: 'src'`, a stray `vite build` would emit to an untracked `src/dist` (only root `dist` is gitignored). If we later want a Vite-based prod build, configure `build.outDir` to a gitignored path first.
-- Verified: `bunx vite build` (to a temp dir) compiles the whole demo cleanly via Vite 8/Rolldown (~310ms); `bun run type-check` passes; biome clean. Did not leave a dev server running.
-- The library build (`bun run build` = bunup) is unaffected by this change.
+- Did not add a `preview` script: with `root: 'src'`, a stray `vite build` would emit to an untracked `src/dist` (only root `dist` is gitignored).
+- issue #157 TDD: wrote the failing slash-format assertions first (7 matches horizontal, 14 vertical), then applied the fix. `grep` for `M/D` across `src/` confirms zero remaining usages. The vertical hourly day header repeats per resource column (7 days × N resources), so the regression test asserts slash-absence rather than an exact element count.
+- Verified: `bun run type-check` clean, full suite 875 pass / 0 fail, biome clean.

--- a/src/features/resource-calendar/components/week-view/horizontal/resource-week-horizontal-day-header.tsx
+++ b/src/features/resource-calendar/components/week-view/horizontal/resource-week-horizontal-day-header.tsx
@@ -40,7 +40,7 @@ export const ResourceWeekHorizontalDayHeader: React.FC<
 						>
 							<div className="text-sm truncate w-full">{day.format('ddd')}</div>
 							<div className="text-xs text-muted-foreground">
-								{day.format('M/D')}
+								{day.format('D')}
 							</div>
 						</div>
 					</AnimatedSection>

--- a/src/features/resource-calendar/components/week-view/horizontal/resource-week-horizontal.test.tsx
+++ b/src/features/resource-calendar/components/week-view/horizontal/resource-week-horizontal.test.tsx
@@ -57,6 +57,18 @@ describe('ResourceWeekHorizontal', () => {
 			expect(dayHeaders.length).toBe(7)
 		})
 
+		test('day headers show only the day number, not the M/D slash format (issue #157)', () => {
+			renderResourceWeekHorizontal()
+
+			// No header should render the M/D slash format (e.g. "1/1", "12/29")
+			expect(screen.queryAllByText(/^\d{1,2}\/\d{1,2}$/)).toHaveLength(0)
+
+			// Jan 1 2025 is a Wednesday; its header shows the bare day number "1"
+			const dayHeaders = screen.getAllByTestId('resource-week-day-header')
+			const wednesday = dayHeaders.find((h) => h.textContent?.includes('Wed'))
+			expect(wednesday?.textContent).toBe('Wed1')
+		})
+
 		test('renders time labels for each hour', () => {
 			renderResourceWeekHorizontal()
 

--- a/src/features/resource-calendar/components/week-view/vertical/resource-week-vertical-day-header.tsx
+++ b/src/features/resource-calendar/components/week-view/vertical/resource-week-vertical-day-header.tsx
@@ -46,7 +46,7 @@ export const ResourceWeekVerticalDayHeader: React.FC<
 							{day.format('ddd')}
 						</div>
 						<div className="text-xs text-muted-foreground">
-							{day.format('M/D')}
+							{day.format('D')}
 						</div>
 					</AnimatedSection>
 				)

--- a/src/features/resource-calendar/components/week-view/vertical/resource-week-vertical.test.tsx
+++ b/src/features/resource-calendar/components/week-view/vertical/resource-week-vertical.test.tsx
@@ -51,6 +51,24 @@ describe('ResourceWeekVertical', () => {
 		expect(screen.getByTestId('vertical-col-time-col')).toBeInTheDocument()
 	})
 
+	test('day headers show only the day number, not the M/D slash format (issue #157)', () => {
+		renderResourceWeekVertical()
+
+		// No header should render the M/D slash format (e.g. "1/1", "12/29")
+		expect(screen.queryAllByText(/^\d{1,2}\/\d{1,2}$/)).toHaveLength(0)
+
+		// Weekday labels still render, so the headers themselves are intact
+		expect(screen.getAllByText('Wed').length).toBeGreaterThan(0)
+	})
+
+	test('daily-mode day column shows only the day number, not M/D (issue #157)', () => {
+		renderResourceWeekVertical({ weekViewGranularity: 'daily' })
+
+		// The daily-mode first column must not use the M/D slash format either
+		expect(screen.queryAllByText(/^\d{1,2}\/\d{1,2}$/)).toHaveLength(0)
+		expect(screen.getAllByText('Wed').length).toBeGreaterThan(0)
+	})
+
 	test('renders day columns for each resource', () => {
 		renderResourceWeekVertical()
 
@@ -343,10 +361,14 @@ describe('ResourceWeekVertical', () => {
 			test('shows week number in the header in daily mode', () => {
 				renderResourceWeekVertical({ weekViewGranularity: 'daily' })
 
-				// Header renders "Week" label and week number as separate spans
+				// Header renders "Week" label and week number as sibling spans in the
+				// same gutter. Scope to that gutter so the week number isn't confused
+				// with a bare day number now that day headers show only "D" (issue #157).
 				const weekNumber = initialDate.week()
-				expect(screen.getByText('Week')).toBeInTheDocument()
-				expect(screen.getByText(String(weekNumber))).toBeInTheDocument()
+				const weekLabel = screen.getByText('Week')
+				expect(weekLabel.parentElement?.textContent).toContain(
+					String(weekNumber)
+				)
 			})
 
 			test('firstCol (date-col) shows day name + date for each day of the week', () => {

--- a/src/features/resource-calendar/components/week-view/vertical/resource-week-vertical.tsx
+++ b/src/features/resource-calendar/components/week-view/vertical/resource-week-vertical.tsx
@@ -34,7 +34,7 @@ export const ResourceWeekVertical: React.FC = () => {
 					) : (
 						<>
 							<span>{date.format('ddd')}</span>
-							<span>{date.format('M/D')}</span>
+							<span>{date.format('D')}</span>
 						</>
 					)}
 				</div>


### PR DESCRIPTION
Closes #157

## Problem

The Resource Week View day headers used the `M/D` slash format (e.g. `5/19`), while the standard Week View shows only the day number (`19`). Reported as a visual inconsistency.

## Fix

Switched the resource week headers to `day.format('D')` to match the standard Week View. Fixed **all three** render paths (the report showed one; grepping `M/D` surfaced the rest):

- `resource-week-horizontal-day-header.tsx` — horizontal day header
- `resource-week-vertical-day-header.tsx` — vertical hourly day header
- `resource-week-vertical.tsx` — vertical daily-mode first column

## Tests

- Added issue #157 regression tests to the existing horizontal/vertical resource-week test files asserting no `M/D` slash format renders in headers, plus a daily-mode case.
- Updated the pre-existing daily-mode "week number" test to scope its assertion to the week gutter: now that day headers show a bare `1`, it collided with week number `1`.

## Verification

- `bun run type-check` clean
- Full suite: 875 pass / 0 fail
- biome clean
- `grep M/D` across `src/` returns nothing after the change