### PR TITLE
perf(build): drop sourcemaps from published package (~0.71 MB → 159 KB)

### DIFF
--- a/docs/logs/2026-06-07.md
+++ b/docs/logs/2026-06-07.md
@@ -2,6 +2,18 @@
 
 ## Changes
 
+- **[build/sourcemaps]**: Stopped shipping sourcemaps in the published package.
+  `calendar/bunup.config.ts` had `sourcemap: true`, which bunup treats as
+  `'inline'` (base64 map embedded in every `.js`) — profiling showed that was
+  **~84% of the shipped bytes** (whole `.js` 634 KB raw / 185 KB gzip vs ~104 KB
+  raw / 32.7 KB gzip of actual code). Switched to `sourcemap: 'none'`: published
+  tarball dropped from ~0.71 MB → **159 KB unpacked**, no `.map` files. (The
+  inline maps never reached consumers' runtime bundles — their bundler strips
+  them — but they bloated install footprint and build-parse. Chose `'none'` over
+  external maps since the source is public on GitHub; matches react-dom/zod,
+  whereas Radix ships external maps. Both are standard; inline was the only
+  wrong option.)
+
 - **[styling/byo]**: `@ilamy/calendar` ships **no CSS** — "bring your own design
   system". Removed the `./styles.css` export and the `styles/` dir from the
   published package. The components use the conventional shadcn token classes

--- a/packages/calendar/bunup.config.ts
+++ b/packages/calendar/bunup.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
 	outDir: 'dist',
 	minify: true,
 	clean: true,
-	sourcemap: true,
+	// No sourcemaps in the published package. `sourcemap: true` embeds an inline
+	// base64 map in every .js (was ~84% of the shipped bytes); we ship code only
+	// (the source is public on GitHub). See bunup docs (true === 'inline').
+	sourcemap: 'none',
 	// Bundle the internal @ilamy/* workspace packages into this output (they're
 	// resolved to source via tsconfig paths). Their third-party deps (react,
 	// radix, clsx, etc.) stay external — see package.json dependencies.


### PR DESCRIPTION
## Drop sourcemaps from the published package

bunup's `sourcemap: true` is treated as `'inline'` ([bunup docs](https://bunup.dev/docs/guide/options): `true === 'inline'`), so it embedded a base64 sourcemap in every emitted `.js`. Profiling the published bundle showed those inline maps were **~84% of the shipped bytes**:

| | raw | gzip |
|---|---|---|
| Whole shipped `.js` (with inline maps) | 634 KB | 185 KB |
| Actual code | ~104 KB | ~32.7 KB |

This switches to `sourcemap: 'none'`, so the package ships **code only**:

- Published tarball: **~0.71 MB → 159 KB unpacked**, no `.map` files.
- The runtime `.js` a consumer's bundler parses drops from ~634 KB → ~104 KB raw.

### Why `'none'` (not external maps)
The inline maps never reached consumers' production bundles (their bundler strips them), but they bloated **install footprint** and **build-parse time**. We chose to ship no maps rather than external `.map` files because the source is public on GitHub — matching `react-dom` and `zod`. (`@radix-ui/*` ships external maps; both are standard. Inline-in-the-runtime-`.js` was the only wrong option.)

### Verification
- `bun run ci` green: calendar 764/764, recurrence 146/146, all type-checks + builds.
- `bun publish --dry-run`: 11 files, 159 KB unpacked, zero `.map`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
