### PR TITLE
fix: deleting an overriding event should not triggerd an update event

### DIFF
--- a/docs/logs/2026-06-14.md
+++ b/docs/logs/2026-06-14.md
@@ -1,0 +1,17 @@
+# Development Log - 2026-06-14
+
+## Changes
+
+- **[recurrence handler — delete "this"]**: Scope-"this" delete now emits exactly one persistence callback. When a stored override is dropped, only `deleted` is reported; otherwise only `updated` (new EXDATE on the base). In-memory state still always applies the EXDATE and removes the override row so the occurrence stays excluded even when the callback is delete-only.
+
+## Files Modified
+
+- `packages/plugins/recurrence/src/utils/delete-recurring-event.ts` - Mutually exclusive `updated` / `deleted` reporting keyed on `droppedOverride`
+- `packages/plugins/recurrence/src/utils/recurring-mutations.test.ts` - Override delete expects delete-only callback
+- `packages/plugins/recurrence/src/utils/crud-operations.test.ts` - Added override vs generated-instance callback test
+- `packages/calendar/src/features/calendar/contexts/calendar-context/provider.test.tsx` - Updated recurring delete callback expectations
+- `packages/calendar/src/features/calendar/hooks/use-calendar-engine.test.ts` - Added override delete integration test
+
+## Notes
+
+Previous attempt skipped EXDATE mutation when the target was an override, which could leave the base without an exclusion and make the occurrence reappear. The correct fix is to keep mutating the store but gate the callbacks: override present → `onEventDelete` only; no override → `onEventUpdate` only.

--- a/packages/calendar/src/features/calendar/contexts/calendar-context/provider.test.tsx
+++ b/packages/calendar/src/features/calendar/contexts/calendar-context/provider.test.tsx
@@ -330,17 +330,10 @@ describe('CalendarProvider - recurring event integration', () => {
 			})
 		)
 
-		// Scope "this" delete on the base: adds the occurrence EXDATE to the base
-		// (onEventUpdate) and drops the detached override created by the edit above
-		// (onEventDelete). It does NOT delete the clicked base row.
+		// Scope "this" delete on the base after an edit: the base already exdates
+		// this occurrence, so only the detached override is reported (onEventDelete).
 		act(() => getByTestId('delete-recurring').click())
-		expect(onEventUpdate).toHaveBeenCalledTimes(2)
-		expect(onEventUpdate).toHaveBeenLastCalledWith(
-			expect.objectContaining({
-				id: 'weekly-meeting',
-				exdates: ['2025-01-06T10:00:00.000Z'],
-			})
-		)
+		expect(onEventUpdate).toHaveBeenCalledTimes(1)
 		expect(onEventDelete).toHaveBeenCalledTimes(1)
 		expect(onEventDelete).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/packages/calendar/src/features/calendar/hooks/use-calendar-engine.test.ts
+++ b/packages/calendar/src/features/calendar/hooks/use-calendar-engine.test.ts
@@ -884,6 +884,29 @@ describe('useCalendarEngine', () => {
 			expect(onEventDelete).not.toHaveBeenCalled()
 		})
 
+		it('should fire only onEventDelete when deleting an occurrence that has a stored override', () => {
+			const occurrenceISO = '2025-01-13T10:00:00.000Z'
+			const base = createRecurringEvent({ exdates: [occurrenceISO] })
+			const override: CalendarEvent = {
+				...base,
+				id: 'recurring-1_override',
+				recurrenceId: occurrenceISO,
+				rrule: undefined,
+				start: dayjs(occurrenceISO),
+				end: dayjs('2025-01-13T11:00:00.000Z'),
+			}
+			const { result, onEventUpdate, onEventDelete } = renderRecurrenceEngine([
+				base,
+				override,
+			])
+
+			act(() => result.current.applyScopedDelete(override, 'this'))
+
+			expect(onEventUpdate).not.toHaveBeenCalled()
+			expect(onEventDelete).toHaveBeenCalledTimes(1)
+			expect(onEventDelete.mock.calls[0][0].id).toBe('recurring-1_override')
+		})
+
 		it('should fire onEventUpdate with base id and until on scope following delete', () => {
 			const base = createRecurringEvent()
 			const instance: CalendarEvent = {

--- a/packages/plugins/recurrence/src/utils/crud-operations.test.ts
+++ b/packages/plugins/recurrence/src/utils/crud-operations.test.ts
@@ -780,6 +780,38 @@ describe('deleteRecurringEvent', () => {
 			expect(updatedEvent.exdates).toContain('2025-01-27T09:00:00.000Z')
 			expect(updatedEvent.exdates).toContain('2025-01-20T09:00:00.000Z')
 		})
+
+		it('should report only delete when an override exists, only update otherwise', () => {
+			const occurrenceISO = '2025-01-20T09:00:00.000Z'
+			const baseEvent = createBaseRecurringEvent({
+				exdates: [occurrenceISO],
+			})
+			const storedOverride = createTargetEvent({
+				id: 'recurring-1_override',
+				recurrenceId: occurrenceISO,
+				rrule: undefined,
+			})
+
+			const overrideDelete = deleteRecurringEvent({
+				targetEvent: storedOverride,
+				currentEvents: [baseEvent, storedOverride],
+				scope: 'this',
+			})
+			expect(overrideDelete.updated).toHaveLength(0)
+			expect(overrideDelete.deleted).toHaveLength(1)
+			expect(overrideDelete.deleted[0].id).toBe('recurring-1_override')
+
+			const freshBase = createBaseRecurringEvent()
+			const generatedInstance = createTargetEvent({ rrule: undefined })
+			const instanceDelete = deleteRecurringEvent({
+				targetEvent: generatedInstance,
+				currentEvents: [freshBase],
+				scope: 'this',
+			})
+			expect(instanceDelete.deleted).toHaveLength(0)
+			expect(instanceDelete.updated).toHaveLength(1)
+			expect(instanceDelete.updated[0].exdates).toContain(occurrenceISO)
+		})
 	})
 
 	describe('scope: "following"', () => {

--- a/packages/plugins/recurrence/src/utils/delete-recurring-event.ts
+++ b/packages/plugins/recurrence/src/utils/delete-recurring-event.ts
@@ -23,7 +23,8 @@ interface ScopedDeleteContext {
 
 /**
  * Scope "this": EXDATE the occurrence on the base and drop any detached override
- * for it. The dropped override is reported in `deleted` so a stored row is removed.
+ * for it. Persistence callbacks are mutually exclusive — report `deleted` when a
+ * stored override is removed, otherwise report `updated` with the new EXDATE.
  */
 const deleteThisScope = ({
 	targetEvent,
@@ -53,7 +54,7 @@ const deleteThisScope = ({
 
 	return {
 		events,
-		updated: [updatedBaseEvent],
+		updated: droppedOverride ? [] : [updatedBaseEvent],
 		added: [],
 		deleted: droppedOverride ? [droppedOverride] : [],
 	}

--- a/packages/plugins/recurrence/src/utils/recurring-mutations.test.ts
+++ b/packages/plugins/recurrence/src/utils/recurring-mutations.test.ts
@@ -119,7 +119,7 @@ describe('recurring mutations', () => {
 			])
 		})
 
-		it('should report dropped override in deleted and base in updated for scope this', () => {
+		it('should report only the override in deleted for scope this when an override exists', () => {
 			const baseEvent = createBaseRecurringEvent({
 				id: 'series-del-this',
 				uid: 'series-del-this@ilamy.calendar',
@@ -135,18 +135,18 @@ describe('recurring mutations', () => {
 			}
 			const currentEvents = [baseEvent, override]
 
-			const { deleted, updated, added } = deleteRecurringEvent({
+			const { deleted, updated, added, events } = deleteRecurringEvent({
 				targetEvent: override,
 				currentEvents,
 				scope: 'this',
 			})
 
 			expect(added).toHaveLength(0)
-			expect(updated).toHaveLength(1)
-			expect(updated[0].id).toBe('series-del-this')
-			expect(updated[0].exdates).toContain(occurrenceISO)
+			expect(updated).toHaveLength(0)
 			expect(deleted).toHaveLength(1)
 			expect(deleted[0].id).toBe('series-del-this_override')
+			expect(events).toHaveLength(1)
+			expect(events[0].exdates).toContain(occurrenceISO)
 		})
 
 		it('should report empty deleted and base in updated for scope this on a generated instance', () => {


### PR DESCRIPTION
## What changed?

fix #156 

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [ ] CI passes locally (`bun run ci`)
- [ ] Changes are tested
- [ ] Code follows project standards
