### PR TITLE
chore(build): drop inline sourcemaps from private packages; doc Fallow --no-cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,11 @@ bun run pre-commit                 # lint:fix + prettier:fix
 bun run build                      # Production build (bunup)
 bun run type-check                 # TypeScript check
 bun run ci                         # Full CI: lint + prettier + test + build
+
+# Match the CI gate locally (Fallow static analysis). Always pass --no-cache:
+# `--changed-since` otherwise registers a per-base-sha git worktree under $TMPDIR
+# as a cache, and those accumulate in `git worktree list`. --no-cache leaves none.
+bunx fallow@2.90.0 audit --changed-since main --gate new-only --no-cache
 ```
 
 ## Architecture

--- a/docs/logs/2026-06-14.md
+++ b/docs/logs/2026-06-14.md
@@ -30,3 +30,16 @@ Previous attempt skipped EXDATE mutation when the target was an override, which 
 
 - Root cause was a referential-stability bug, not the recurrence handler. Verified the recurrence/transform + engine layers persist overrides across navigation when the events prop is stable; the new array each render was the trigger.
 - Separate (not fixed here): the `use-calendar-data` sync still discards internal edits whenever a consumer legitimately changes the `events` prop. Defensible for controlled events, but worth revisiting.
+
+## Changes (drop inline sourcemaps from private packages)
+
+- **[build]**: Removed `sourcemap: true` from the bunup configs of the private, bundled packages (`@ilamy/ui`, `@ilamy/utils`, `@ilamy/calendar-recurrence`, `@ilamy/calendar-agenda`). In bunup `true` means *inline* base64 maps embedded in every `.js` (verified in bunup 0.16.32: `sourcemap === true` → `"inline"`). These packages are private and bundled into `@ilamy/calendar` from source, so their dist (and its maps) is never shipped or used at runtime; the inline maps were pure bloat. Omitting the option resolves to no sourcemap. The published `@ilamy/calendar` already used `sourcemap: 'none'`.
+
+## Files Modified (sourcemaps)
+
+- `packages/ui/bunup.config.ts`, `packages/utils/bunup.config.ts`, `packages/plugins/recurrence/bunup.config.ts`, `packages/plugins/agenda/bunup.config.ts` - Dropped `sourcemap: true`.
+
+## Notes (sourcemaps)
+
+- Verified: full build succeeds and no `sourceMappingURL=data:...base64` remains in any private dist.
+- Documented in `AGENTS.md`: run Fallow locally with `--no-cache`. Without it, `--changed-since` registers a per-base-sha worktree under `$TMPDIR` (Fallow's base-snapshot cache) that accumulates in `git worktree list`; `--no-cache` leaves none. CI (the Fallow action on an ephemeral runner) is unaffected.

--- a/packages/plugins/agenda/bunup.config.ts
+++ b/packages/plugins/agenda/bunup.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
 	outDir: 'dist',
 	minify: true,
 	clean: true,
-	sourcemap: true,
 	external: [
 		'react',
 		'react-dom',

--- a/packages/plugins/recurrence/bunup.config.ts
+++ b/packages/plugins/recurrence/bunup.config.ts
@@ -9,6 +9,5 @@ export default defineConfig({
 	outDir: 'dist',
 	minify: true,
 	clean: true,
-	sourcemap: true,
 	external: ['react', 'react-dom', '@ilamy/calendar', /^@ilamy\/ui/, 'rrule'],
 })

--- a/packages/ui/bunup.config.ts
+++ b/packages/ui/bunup.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
 	outDir: 'dist',
 	minify: true,
 	clean: true,
-	sourcemap: true,
 	// Stock shadcn primitives have no explicit return types; use full TS
 	// inference for .d.ts instead of isolated declarations (which would require
 	// annotating every component). These are leaf files, so the slower dts is

--- a/packages/utils/bunup.config.ts
+++ b/packages/utils/bunup.config.ts
@@ -11,6 +11,5 @@ export default defineConfig({
 	outDir: 'dist',
 	minify: true,
 	clean: true,
-	sourcemap: true,
 	external: ['dayjs', /^dayjs\//],
 })


### PR DESCRIPTION
## Sourcemaps

bunup's `sourcemap: true` resolves to **inline** base64 maps embedded in every `.js` (verified in bunup 0.16.32: `sourcemap === true` → `"inline"`). It was set on four packages that are all `private` and bundled into `@ilamy/calendar` from source, so their dist (and its maps) is never shipped or used at runtime. Dropped the option (omitting it resolves to no sourcemap). The published `@ilamy/calendar` already used `sourcemap: 'none'`.

- `packages/ui`, `packages/utils`, `packages/plugins/recurrence`, `packages/plugins/agenda` bunup configs.
- Verified: full build succeeds, no `sourceMappingURL=data:…base64` remains in any private dist, calendar still map-free.

## Fallow --no-cache note

Documented in `AGENTS.md` that local Fallow runs should pass `--no-cache`. Without it, `--changed-since` registers a per-base-sha worktree under `$TMPDIR` (Fallow's base-snapshot cache) that accumulates in `git worktree list`. `--no-cache` leaves none. CI (the Fallow action on an ephemeral runner) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)