### PR TITLE
feat(agenda): fdow-aware week window, drop year window, live demo window control

### DIFF
--- a/apps/demo/src/components/demo/demo-calendar-display.tsx
+++ b/apps/demo/src/components/demo/demo-calendar-display.tsx
@@ -4,6 +4,7 @@ import type {
 	CalendarView,
 	CellInfo,
 	Dayjs,
+	IlamyPlugin,
 	RenderCurrentTimeIndicatorProps,
 	Resource,
 	SlotDuration,
@@ -18,7 +19,6 @@ import {
 	renderHour,
 } from './demo-custom-renderers'
 import {
-	demoPlugins,
 	handleDateClick,
 	handleEventAdd,
 	handleEventClick,
@@ -50,6 +50,7 @@ type SharedCalendarProps = {
 	}[]
 	classesOverride: CalendarClassesOverride | undefined
 	dayMaxEvents: number
+	plugins: IlamyPlugin[]
 	disableCellClick: boolean
 	disableDragAndDrop: boolean
 	disableEventClick: boolean
@@ -82,6 +83,7 @@ function RegularCalendar({
 	businessHours,
 	classesOverride,
 	dayMaxEvents,
+	plugins,
 	disableCellClick,
 	disableDragAndDrop,
 	disableEventClick,
@@ -129,7 +131,7 @@ function RegularCalendar({
 			onEventClick={onEventClick}
 			onEventDelete={handleEventDelete}
 			onEventUpdate={handleEventUpdate}
-			plugins={demoPlugins}
+			plugins={plugins}
 			renderCurrentTimeIndicator={timeIndicator}
 			renderEvent={renderEvent}
 			renderHour={hourRenderer}
@@ -156,6 +158,7 @@ function ResourceCalendar({
 	businessHours,
 	classesOverride,
 	dayMaxEvents,
+	plugins,
 	disableCellClick,
 	disableDragAndDrop,
 	disableEventClick,
@@ -207,7 +210,7 @@ function ResourceCalendar({
 			onEventDelete={handleEventDelete}
 			onEventUpdate={handleEventUpdate}
 			orientation={orientation}
-			plugins={demoPlugins}
+			plugins={plugins}
 			renderCurrentTimeIndicator={timeIndicator}
 			renderEvent={renderEvent}
 			renderHour={hourRenderer}
@@ -228,6 +231,7 @@ type DemoCalendarDisplayProps = {
 	calendarKey: string
 	businessHours: SharedCalendarProps['businessHours']
 	dayMaxEvents: number
+	plugins: IlamyPlugin[]
 	disableCellClick: boolean
 	disableDragAndDrop: boolean
 	disableEventClick: boolean
@@ -275,6 +279,7 @@ function resolveSharedCalendarProps(
 	return {
 		businessHours: props.businessHours,
 		dayMaxEvents: props.dayMaxEvents,
+		plugins: props.plugins,
 		disableCellClick: props.disableCellClick,
 		disableDragAndDrop: props.disableDragAndDrop,
 		disableEventClick: props.disableEventClick,

--- a/apps/demo/src/components/demo/demo-calendar-settings.tsx
+++ b/apps/demo/src/components/demo/demo-calendar-settings.tsx
@@ -7,6 +7,7 @@ import type {
 	WeekDays,
 } from '@ilamy/calendar'
 import { type Dayjs, dayjs } from '@ilamy/calendar'
+import type { AgendaWindow } from '@ilamy/calendar/plugins/agenda'
 import { Button } from '@ilamy/ui/components/button'
 import {
 	Card,
@@ -35,6 +36,8 @@ interface DemoCalendarSettingsProps {
 	setFirstDayOfWeek: (value: WeekDays) => void
 	initialView: CalendarView
 	setInitialView: (value: CalendarView) => void
+	agendaWindow: AgendaWindow
+	setAgendaWindow: (value: AgendaWindow) => void
 	initialDate: Dayjs | undefined
 	setInitialDate: (value: Dayjs | undefined) => void
 	useCustomEventRenderer: boolean
@@ -93,6 +96,15 @@ interface DemoCalendarSettingsProps {
 	setScrollTime: (value: string | undefined) => void
 }
 
+// The agenda window is a Select of strings; named periods pass through, numeric
+// options ('3' / '14') parse to a rolling N-day window.
+function parseAgendaWindow(value: string): AgendaWindow {
+	if (value === 'day' || value === 'week' || value === 'month') {
+		return value
+	}
+	return Number(value)
+}
+
 function resolveInitialDateOption(initialDate: Dayjs | undefined): string {
 	if (initialDate === undefined) {
 		return 'today'
@@ -116,6 +128,8 @@ export function DemoCalendarSettings({
 	setFirstDayOfWeek,
 	initialView,
 	setInitialView,
+	agendaWindow,
+	setAgendaWindow,
 	initialDate,
 	setInitialDate,
 	useCustomEventRenderer,
@@ -313,6 +327,28 @@ export function DemoCalendarSettings({
 						</SelectContent>
 					</Select>
 				</label>
+				{!isResourceCalendar && (
+					<label className="block text-sm text-left font-medium mb-1">
+						<span>Agenda Window</span>
+						<Select
+							onValueChange={(value) =>
+								setAgendaWindow(parseAgendaWindow(value))
+							}
+							value={String(agendaWindow)}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Select agenda window" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="day">Day</SelectItem>
+								<SelectItem value="week">Week</SelectItem>
+								<SelectItem value="month">Month</SelectItem>
+								<SelectItem value="3">Next 3 days</SelectItem>
+								<SelectItem value="14">Next 14 days</SelectItem>
+							</SelectContent>
+						</Select>
+					</label>
+				)}
 				<label className="block text-sm text-left font-medium mb-1">
 					<span>Initial Date</span>
 					<Select

--- a/apps/demo/src/components/demo/demo-data.ts
+++ b/apps/demo/src/components/demo/demo-data.ts
@@ -1,12 +1,20 @@
-import type { CalendarEvent, CellInfo, Resource } from '@ilamy/calendar'
-import { agendaPlugin } from '@ilamy/calendar/plugins/agenda'
+import type {
+	CalendarEvent,
+	CellInfo,
+	IlamyPlugin,
+	Resource,
+} from '@ilamy/calendar'
+import { type AgendaWindow, agendaPlugin } from '@ilamy/calendar/plugins/agenda'
 import { recurrencePlugin } from '@ilamy/calendar/plugins/recurrence'
 import { dummyEvents } from '@/lib/seed'
 
 // Recurrence and agenda are opt-in plugins. The seed data has recurring events,
-// so recurrence expands them; agenda adds the upcoming-events list view. Kept
-// module-level so the array reference is stable across renders.
-export const demoPlugins = [recurrencePlugin(), agendaPlugin()]
+// so recurrence expands them; agenda adds the upcoming-events list view scoped
+// to `agendaWindow`. Built per-window so the demo can change the window live;
+// memoize the result in the caller to keep the array reference stable.
+export const createDemoPlugins = (
+	agendaWindow: AgendaWindow
+): IlamyPlugin[] => [recurrencePlugin(), agendaPlugin({ window: agendaWindow })]
 
 // Event handlers kept module-level to avoid recreation across renders.
 export const handleEventClick = (event: CalendarEvent) => {

--- a/apps/demo/src/components/demo/demo-page.tsx
+++ b/apps/demo/src/components/demo/demo-page.tsx
@@ -6,11 +6,16 @@ import type {
 	TimeFormat,
 	WeekDays,
 } from '@ilamy/calendar'
-import { useState } from 'react'
+import type { AgendaWindow } from '@ilamy/calendar/plugins/agenda'
+import { useMemo, useState } from 'react'
 import { dummyEvents } from '@/lib/seed'
 import { DemoCalendarDisplay } from './demo-calendar-display'
 import { DemoCalendarSettings } from './demo-calendar-settings'
-import { createResourceEvents, demoResources } from './demo-data'
+import {
+	createDemoPlugins,
+	createResourceEvents,
+	demoResources,
+} from './demo-data'
 import { DemoResourcePicker } from './demo-resource-picker'
 
 // Import all dayjs locales alphabetically
@@ -168,6 +173,10 @@ export function DemoPage() {
 	// Calendar configuration state
 	const [firstDayOfWeek, setFirstDayOfWeek] = useState<WeekDays>('sunday')
 	const [initialView, setInitialView] = useState<CalendarView>('month')
+	// The agenda window is a developer config; rebuild the plugins array only
+	// when it changes so the calendar's `plugins` prop stays referentially stable.
+	const [agendaWindow, setAgendaWindow] = useState<AgendaWindow>('week')
+	const plugins = useMemo(() => createDemoPlugins(agendaWindow), [agendaWindow])
 	const [initialDate, setInitialDate] = useState<Dayjs | undefined>(undefined)
 	const [customEvents] = useState<CalendarEvent[]>(dummyEvents)
 	const [resourceEvents] = useState<CalendarEvent[]>(createResourceEvents())
@@ -269,6 +278,7 @@ export function DemoPage() {
 				{/* Calendar settings sidebar */}
 				<div className="lg:col-span-1 space-y-6">
 					<DemoCalendarSettings
+						agendaWindow={agendaWindow}
 						businessEndTime={businessEndTime}
 						businessStartTime={businessStartTime}
 						calendarHeight={calendarHeight}
@@ -287,6 +297,7 @@ export function DemoPage() {
 						locale={locale}
 						orientation={orientation}
 						scrollTime={scrollTime}
+						setAgendaWindow={setAgendaWindow}
 						setBusinessEndTime={setBusinessEndTime}
 						setBusinessStartTime={setBusinessStartTime}
 						setCalendarHeight={setCalendarHeight}
@@ -361,6 +372,7 @@ export function DemoPage() {
 						locale={locale}
 						onDateChange={handleDateChange}
 						orientation={orientation}
+						plugins={plugins}
 						resourceEvents={resourceEvents}
 						scrollTime={scrollTime}
 						slotDuration={slotDuration}

--- a/docs/logs/2026-06-14.md
+++ b/docs/logs/2026-06-14.md
@@ -43,3 +43,31 @@ Previous attempt skipped EXDATE mutation when the target was an override, which 
 
 - Verified: full build succeeds and no `sourceMappingURL=data:...base64` remains in any private dist.
 - Documented in `AGENTS.md`: run Fallow locally with `--no-cache`. Without it, `--changed-since` registers a per-base-sha worktree under `$TMPDIR` (Fallow's base-snapshot cache) that accumulates in `git worktree list`; `--no-cache` leaves none. CI (the Fallow action on an ephemeral runner) is unaffected.
+
+## Changes (agenda window refinements — single-view "Schedule" model)
+
+Followed #139's intent: the agenda is one chronological upcoming-events list (Google Calendar "Schedule"), not a set of day/week/month agenda views. Briefly prototyped multi-window agenda + a grouped/dropdown switcher, but it put a second Day/Week/Month next to the grid views' Day/Week/Month, which read as confusing duplication. Reverted that; kept the window as a single developer config and the genuinely-good fixes below.
+
+- **[agenda — single window config]**: `agendaPlugin({ window })` / `createAgendaView({ window })` registers one `agenda` view (unchanged API). `window: AgendaWindow = 'day' | 'week' | 'month' | number`, default `'month'`. Named periods are the calendar period *containing* the current date (so 'month' on the 14th lists from the 1st, matching the grid view + header); a number is a rolling window of N days *from* the current date forward (e.g. `8` on the 14th lists the 14th–21st). This named-vs-numeric anchoring is intentional and documented on `AgendaWindow` + `AgendaViewOptions.window`.
+- **[agenda — fdow-aware week]**: The `week` window aligns to `config.firstDayOfWeek` (`createAgendaView`'s `range` passes it through; `AgendaView` threads `firstDayOfWeek` from context into `windowRange`).
+- **[agenda — dropped year window]**: Removed `'year'` from `AgendaWindow` (a year-long event list is unhelpful).
+- **[agenda — empty state]**: Centered the empty-window message (`flex h-full items-center justify-center`) so a short window (e.g. a day) doesn't pin "No upcoming events" to the corner. Sparse non-empty lists still flow from the top (reads like an inbox).
+
+## Files Modified (agenda window refinements)
+
+- `packages/plugins/agenda/src/utils/agenda-window.ts` - Removed `year`; documented named-vs-numeric anchoring; `windowRange` takes `firstDayOfWeek` for the week window.
+- `packages/plugins/agenda/src/utils/create-agenda-view.ts` - `range` passes `config.firstDayOfWeek`; expanded the `window` doc.
+- `packages/plugins/agenda/src/components/agenda-view.tsx` - `firstDayOfWeek` from context into `windowRange`; centered empty state.
+- `packages/plugins/agenda/src/utils/create-agenda-view.test.ts` - Added day-window and fdow-aware week-window range tests.
+- `packages/plugins/agenda/src/components/agenda-view.test.tsx` - `renderAgenda` takes a window; added a day-window event-scoping test.
+- `apps/demo/src/components/demo/demo-data.ts` - Replaced the module-level `demoPlugins` with `createDemoPlugins(agendaWindow)` so the window can vary at runtime.
+- `apps/demo/src/components/demo/demo-page.tsx` - Added `agendaWindow` state (default 'week') + a `useMemo` plugins array (stable unless the window changes); threads `plugins` to the display and `agendaWindow`/`setAgendaWindow` to settings.
+- `apps/demo/src/components/demo/demo-calendar-settings.tsx` - Added an "Agenda Window" Select (Day/Week/Month/Next 3 days/Next 14 days), shown for the regular calendar; `parseAgendaWindow` maps the string value back to a named period or numeric window.
+- `apps/demo/src/components/demo/demo-calendar-display.tsx` - Takes `plugins` as a prop (threaded to both calendar variants) instead of importing the module-level constant.
+
+Live update works without a remount: `use-calendar-engine` derives the plugin runtime via `useMemo(() => createPluginRuntime(plugins), [plugins])`, so a new memoized plugins array re-registers the agenda view with the new window while navigation state is preserved.
+
+## Notes (agenda window refinements)
+
+- Reviewed FullCalendar (listDay/listWeek/listMonth as selectable views) and Full Event Calendar (a List/Calendar display-mode toggle orthogonal to day/week/month). Both keep agenda at multiple granularities, but #139 and its one real consumer asked for a single upcoming-events list with a *developer-configured* window (`createAgendaView({ days })`), not an end-user granularity switcher. So agenda stays a single view; the FEC display-mode toggle would be a switcher rebuild for a capability nobody requested (YAGNI), and it drags in a year-has-no-list-counterpart edge.
+- Reverted in full: `PluginView.group`, the `windows[]` plugin option, the grouped/Popover switcher in `view-controls.tsx`, and the multi-window demo wiring. No public-API change versus main for the switcher or the plugin option.

--- a/packages/plugins/agenda/src/components/agenda-view.test.tsx
+++ b/packages/plugins/agenda/src/components/agenda-view.test.tsx
@@ -4,6 +4,7 @@ import { useIlamyCalendarContext } from '@ilamy/calendar'
 import { CalendarTestProvider } from '@ilamy/calendar/testing'
 import dayjs from '@ilamy/utils/dayjs'
 import { fireEvent, render, screen } from '@testing-library/react'
+import type { AgendaWindow } from '../utils/agenda-window'
 import { AgendaView } from './agenda-view'
 
 /** Surfaces the form-open state so a click's effect on context is observable. */
@@ -30,10 +31,14 @@ const mkEvent = (
 	...extra,
 })
 
-const renderAgenda = (events: CalendarEvent[], initialDateISO = '2026-06-13') =>
+const renderAgenda = (
+	events: CalendarEvent[],
+	window: AgendaWindow = 'month',
+	initialDateISO = '2026-06-13'
+) =>
 	render(
 		<CalendarTestProvider events={events} initialDate={dayjs(initialDateISO)}>
-			<AgendaView window="month" />
+			<AgendaView window={window} />
 		</CalendarTestProvider>
 	)
 
@@ -86,6 +91,16 @@ describe('AgendaView', () => {
 		fireEvent.click(screen.getByRole('button', { name: /Meeting/ }))
 
 		expect(screen.getByTestId('probe')).toHaveTextContent('open:m')
+	})
+
+	it('scopes events to the window: a day window drops events on other days', () => {
+		// Reference day is 2026-06-13 (Meeting); Trip is on 06-20.
+		const { container } = renderAgenda(seed, 'day')
+		const keys = Array.from(
+			container.querySelectorAll('[data-testid^="agenda-day-"]')
+		).map((el) => el.getAttribute('data-testid'))
+		expect(keys).toEqual(['agenda-day-2026-06-13'])
+		expect(screen.queryByText('Trip')).not.toBeInTheDocument()
 	})
 
 	it('shows the empty state when no events fall in the window', () => {

--- a/packages/plugins/agenda/src/components/agenda-view.tsx
+++ b/packages/plugins/agenda/src/components/agenda-view.tsx
@@ -14,16 +14,19 @@ interface AgendaViewProps {
  * the year view) so it is independent of the active view's range.
  */
 export const AgendaView = ({ window }: AgendaViewProps) => {
-	const { currentDate, getEventsForDateRange, t } = useIlamyCalendarContext()
+	const { currentDate, getEventsForDateRange, t, firstDayOfWeek } =
+		useIlamyCalendarContext()
 
-	const range = windowRange(currentDate, window)
+	const range = windowRange(currentDate, window, firstDayOfWeek)
 	const events = getEventsForDateRange(range.start, range.end)
 	const groups = groupEventsByDay(events, range)
 
+	// An empty window (common for short windows like a day agenda) centers the
+	// message in the available space rather than pinning it to the corner.
 	if (groups.length === 0) {
 		return (
 			<div
-				className="text-muted-foreground p-4 text-sm"
+				className="text-muted-foreground flex h-full items-center justify-center p-4 text-sm"
 				data-testid="agenda-empty"
 			>
 				{t('agendaNoEvents')}
@@ -31,6 +34,8 @@ export const AgendaView = ({ window }: AgendaViewProps) => {
 		)
 	}
 
+	// A sparse list flows from the top and scrolls when it overflows; the empty
+	// space below a short list reads as a normal list (like an inbox), not broken.
 	return (
 		<ScrollArea className="h-full" data-testid="agenda-view">
 			<div className="flex flex-col">

--- a/packages/plugins/agenda/src/utils/agenda-window.ts
+++ b/packages/plugins/agenda/src/utils/agenda-window.ts
@@ -1,28 +1,62 @@
 import type { Dayjs } from '@ilamy/calendar'
 
-/** 'month' = the calendar month containing the date; a number = that many days from the date. */
-export type AgendaWindow = 'month' | number
+/**
+ * The date window the agenda lists (and that prev/next steps over).
+ *
+ * A named period is the calendar period *containing* the reference date, so it
+ * can extend backward to the period's start (e.g. 'month' on the 14th lists from
+ * the 1st) and stays aligned with the matching grid view and header label. A
+ * number is a rolling window of that many days starting *at* the reference date
+ * and counting forward (e.g. 8 on the 14th lists the 14th–21st) — there is no
+ * calendar boundary to anchor it to, so it does not look backward.
+ */
+export type AgendaWindow = 'day' | 'week' | 'month' | number
 
-/** The date window the agenda lists, derived from the reference date. */
+type NamedWindow = Exclude<AgendaWindow, number>
+type Range = { start: Dayjs; end: Dayjs }
+type Step = { amount: number; unit: 'day' | 'week' | 'month' }
+
+const namedRange: Record<
+	NamedWindow,
+	(date: Dayjs, firstDayOfWeek: number) => Range
+> = {
+	day: (date) => ({ start: date.startOf('day'), end: date.endOf('day') }),
+	week: (date, firstDayOfWeek) => {
+		const offset = (date.day() - firstDayOfWeek + 7) % 7
+		const start = date.subtract(offset, 'day').startOf('day')
+		return { start, end: start.add(6, 'day').endOf('day') }
+	},
+	month: (date) => ({ start: date.startOf('month'), end: date.endOf('month') }),
+}
+
+const namedStep: Record<NamedWindow, Step> = {
+	day: { amount: 1, unit: 'day' },
+	week: { amount: 1, unit: 'week' },
+	month: { amount: 1, unit: 'month' },
+}
+
+/**
+ * The date window the agenda lists, derived from the reference date.
+ * `firstDayOfWeek` aligns the 'week' window; ignored for other windows.
+ */
 export const windowRange = (
 	date: Dayjs,
-	window: AgendaWindow
-): { start: Dayjs; end: Dayjs } => {
-	if (window === 'month') {
-		return { start: date.startOf('month'), end: date.endOf('month') }
+	window: AgendaWindow,
+	firstDayOfWeek = 0
+): Range => {
+	if (typeof window === 'number') {
+		return {
+			start: date.startOf('day'),
+			end: date.add(window - 1, 'day').endOf('day'),
+		}
 	}
-	return {
-		start: date.startOf('day'),
-		end: date.add(window - 1, 'day').endOf('day'),
-	}
+	return namedRange[window](date, firstDayOfWeek)
 }
 
 /** How far prev/next steps for the window. */
-export const windowStep = (
-	window: AgendaWindow
-): { amount: number; unit: 'month' | 'day' } => {
-	if (window === 'month') {
-		return { amount: 1, unit: 'month' }
+export const windowStep = (window: AgendaWindow): Step => {
+	if (typeof window === 'number') {
+		return { amount: window, unit: 'day' }
 	}
-	return { amount: window, unit: 'day' }
+	return namedStep[window]
 }

--- a/packages/plugins/agenda/src/utils/create-agenda-view.test.ts
+++ b/packages/plugins/agenda/src/utils/create-agenda-view.test.ts
@@ -17,6 +17,27 @@ describe('createAgendaView', () => {
 		expect(range?.end.format('YYYY-MM-DD')).toBe('2026-06-30')
 	})
 
+	it('scopes a day window to the reference day', () => {
+		const view = createAgendaView({ window: 'day' })
+		expect(view.navigationStep).toEqual({ amount: 1, unit: 'day' })
+		const range = view.range?.(date, cfg)
+		expect(range?.start.format('YYYY-MM-DD')).toBe('2026-06-13')
+		expect(range?.end.format('YYYY-MM-DD')).toBe('2026-06-13')
+	})
+
+	it('aligns a week window to firstDayOfWeek', () => {
+		const view = createAgendaView({ window: 'week' })
+		expect(view.navigationStep).toEqual({ amount: 1, unit: 'week' })
+		// 2026-06-13 is a Saturday; Sunday-start week is 06-07..06-13.
+		const sundayStart = view.range?.(date, { firstDayOfWeek: 0 })
+		expect(sundayStart?.start.format('YYYY-MM-DD')).toBe('2026-06-07')
+		expect(sundayStart?.end.format('YYYY-MM-DD')).toBe('2026-06-13')
+		// Monday-start week shifts to 06-08..06-14.
+		const mondayStart = view.range?.(date, { firstDayOfWeek: 1 })
+		expect(mondayStart?.start.format('YYYY-MM-DD')).toBe('2026-06-08')
+		expect(mondayStart?.end.format('YYYY-MM-DD')).toBe('2026-06-14')
+	})
+
 	it('supports a fixed N-day window stepped by N days', () => {
 		const view = createAgendaView({ window: 7 })
 		expect(view.navigationStep).toEqual({ amount: 7, unit: 'day' })

--- a/packages/plugins/agenda/src/utils/create-agenda-view.ts
+++ b/packages/plugins/agenda/src/utils/create-agenda-view.ts
@@ -5,7 +5,13 @@ import { AgendaView } from '../components/agenda-view'
 import { type AgendaWindow, windowRange, windowStep } from './agenda-window'
 
 export interface AgendaViewOptions {
-	/** The date window the agenda lists and that prev/next steps over. Default 'month'. */
+	/**
+	 * The date window the agenda lists and that prev/next steps over. Default 'month'.
+	 * A named period ('day' | 'week' | 'month') is the calendar period *containing*
+	 * the current date, so it can include earlier days of that period (and aligns
+	 * with the matching grid view + header label). A number is a rolling window of
+	 * that many days starting *at* the current date and counting forward.
+	 */
 	window?: AgendaWindow
 }
 
@@ -17,7 +23,7 @@ export const createAgendaView = ({
 	label: 'agenda',
 	icon: List,
 	navigationStep: windowStep(window),
-	range: (date) => windowRange(date, window),
+	range: (date, config) => windowRange(date, window, config.firstDayOfWeek),
 	supportsResources: false,
 	component: () => createElement(AgendaView, { window }),
 })


### PR DESCRIPTION
## Summary

Refines the agenda view (single "Schedule"-style upcoming-events list, per #139) and adds a live window control to the demo.

- **firstDayOfWeek-aware week window** — the `'week'` window now aligns to `config.firstDayOfWeek` (`createAgendaView`'s `range` passes it through; `AgendaView` threads `firstDayOfWeek` from context).
- **Dropped the `'year'` window** from `AgendaWindow` — a year-long event list isn't useful.
- **Documented the named-vs-numeric anchoring** on `AgendaWindow` / `AgendaViewOptions.window`: a named period (`'day' | 'week' | 'month'`) is the calendar period *containing* the current date (so `'month'` on the 14th lists from the 1st, matching the grid view + header); a number is a rolling window of N days *from* the current date forward (e.g. `8` on the 14th lists the 14th–21st).
- **Centered the empty-window state** so a short window doesn't pin "No upcoming events" to the corner.
- **Demo: live "Agenda Window" setting** (Day / Week / Month / Next 3 days / Next 14 days). `demoPlugins` became `createDemoPlugins(agendaWindow)` + a memoized plugins array; the calendar re-registers the view live (no remount) since `use-calendar-engine` derives its runtime via `useMemo(() => createPluginRuntime(plugins), [plugins])`.

## Context

An earlier iteration prototyped multi-window agenda views + a grouped/dropdown switcher, but that put a second Day/Week/Month next to the grid views' Day/Week/Month (confusing duplication). Reverted in full; agenda stays a single view with a developer-configured window. See the dev log for the reasoning.

## Testing

- `bun run type-check` — clean
- `bun run test` — agenda 19, recurrence 165, calendar 786, 0 fail
- `bun run build` — succeeds
- `bun run pre-commit` — clean
- Fallow `--gate new-only --no-cache` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)