### PR TITLE
docs(website): update docs for v2 + add Plugins section

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -73,6 +73,13 @@ export default defineConfig({
 					],
 				},
 				{
+					label: 'Plugins',
+					items: [
+						{ label: 'Recurrence', slug: 'docs/plugins/recurrence' },
+						{ label: 'Agenda', slug: 'docs/plugins/agenda' },
+					],
+				},
+				{
 					label: 'Features',
 					items: [
 						{
@@ -80,7 +87,6 @@ export default defineConfig({
 							slug: 'docs/features/internationalization',
 						},
 						{ label: 'iCal Export', slug: 'docs/features/ical-export' },
-						{ label: 'Recurrence', slug: 'docs/features/recurrence' },
 					],
 				},
 				{

--- a/apps/website/src/content/docs/components/calendar.mdx
+++ b/apps/website/src/content/docs/components/calendar.mdx
@@ -20,7 +20,7 @@ const events = [
     start: new Date('2024-01-15T10:00:00'),
     end: new Date('2024-01-15T11:00:00'),
     description: 'Weekly team sync',
-    backgroundColor: '#3b82f6'
+    backgroundColor: '#3b82f6',
     color: 'black'
   },
   {
@@ -29,7 +29,7 @@ const events = [
     start: new Date('2024-01-20T23:59:59'),
     end: new Date('2024-01-20T23:59:59'),
     allDay: true,
-    backgroundColor: '#ef4444'
+    backgroundColor: '#ef4444',
     color: 'black'
   }
 ];
@@ -41,6 +41,28 @@ function MyCalendar() {
 }
 ```
 
+## Plugins
+
+The v2 core is plugin-agnostic and ships **no plugins by default**. Capabilities like recurring events and the agenda view are opt-in plugins you register through the `plugins` prop. Each plugin is imported from its own subpath so you only ship the code you use.
+
+```tsx
+import { IlamyCalendar } from '@ilamy/calendar';
+import { recurrencePlugin } from '@ilamy/calendar/plugins/recurrence';
+import { agendaPlugin } from '@ilamy/calendar/plugins/agenda';
+
+<IlamyCalendar
+  events={events}
+  plugins={[recurrencePlugin(), agendaPlugin({ window: 'week' })]}
+/>
+```
+
+| Plugin | Import | Adds |
+|--------|--------|------|
+| `recurrencePlugin()` | `@ilamy/calendar/plugins/recurrence` | RFC 5545 recurring-event expansion, scoped edit/delete, and the `rrule`/`recurrenceId`/`exdates` fields on `CalendarEvent`. See [Recurring Events](/docs/plugins/recurrence). |
+| `agendaPlugin({ window })` | `@ilamy/calendar/plugins/agenda` | An agenda (upcoming-events list) view scoped to a `window` (`'day' \| 'week' \| 'month'`). |
+
+The only valid import entry points are `@ilamy/calendar`, `@ilamy/calendar/plugins/recurrence`, and `@ilamy/calendar/plugins/agenda` (plus `@ilamy/calendar/testing`). Deep imports into the package internals are blocked in v2.
+
 ## Props
 
 ### Basic Props
@@ -48,7 +70,12 @@ function MyCalendar() {
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `events` | `CalendarEvent[]` | `[]` | Array of events to display in the calendar |
-| `initialView` | `'month' \| 'week' \| 'day' \| 'year'` | `'month'` | Sets the initial view when the calendar loads |
+| `plugins` | `IlamyPlugin[]` | `[]` | Opt-in plugins that add behavior/UI. The core ships none; pass `recurrencePlugin()` for recurring events or `agendaPlugin()` for the agenda view. See [Plugins](#plugins) below. |
+| `resources` | `Resource[]` | `[]` | Resources (rooms, people, equipment) to render as a resource axis. See [Resource Calendar](/docs/components/resource-calendar). |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Resource axis arrangement. Only applies when `resources` is set. |
+| `renderResource` | `(resource: Resource) => ReactNode` | - | Custom renderer for resource header cells. |
+| `weekViewGranularity` | `'hourly' \| 'daily'` | `'hourly'` | Week-view slot granularity when `resources` is set. |
+| `initialView` | `CalendarView` (`'month' \| 'week' \| 'day' \| 'year'`, or a plugin view name) | `'month'` | Sets the initial view when the calendar loads. `CalendarView` is `string` in v2 so plugins can register extra views. |
 | `initialDate` | `dayjs.Dayjs \| Date \| string \| undefined` | `undefined` (today's date) | Sets the initial date displayed when the calendar loads. When undefined, defaults to today's date |
 | `firstDayOfWeek` | `'sunday' \| 'monday' \| 'tuesday' \| 'wednesday' \| 'thursday' \| 'friday' \| 'saturday'` | `'sunday'` | The first day of the week to display |
 | `dayMaxEvents` | `number` | `4` | Maximum number of events to display in a day cell |
@@ -755,21 +782,25 @@ function CalendarWithAPI() {
 
 The main event object used throughout the calendar. All events passed to the calendar should conform to this interface.
 
-```typescript title="CalendarEvent Interface"
+```typescript title="CalendarEvent (events prop input)"
 interface CalendarEvent {
-  id: string;              // Unique identifier for the event
+  id: string | number;     // Unique identifier for the event
   title: string;           // Display title of the event
-  start: Date;             // Start date and time
-  end: Date;               // End date and time
+  start: Dayjs | Date | string; // Start — accepted as Dayjs, Date, or ISO string
+  end: Dayjs | Date | string;   // End — accepted as Dayjs, Date, or ISO string
   description?: string;    // Optional description text
+  location?: string;       // Optional location
+  uid?: string;            // Optional iCalendar UID (used to group recurring series)
   color?: string;          // Optional text color (hex, rgb, named colors, class names)
   backgroundColor?: string; // Optional background color (hex, rgb, named colors, class names)
   allDay?: boolean;        // Whether this is an all-day event
   resourceId?: string | number;  // Single resource assignment (for resource calendars)
   resourceIds?: (string | number)[]; // Multiple resource assignment (for cross-resource events)
-  data?: Record<string, any>; // Optional custom data for additional properties
+  data?: Record<string, unknown>; // Optional custom data (narrow or cast when reading)
 }
 ```
+
+The `events` prop accepts `start` / `end` as a `Dayjs`, a `Date`, or an ISO string; the calendar normalizes them to `Dayjs` internally, so reads from `useIlamyCalendarContext()` always return `Dayjs`. With the recurrence plugin registered, `rrule`, `recurrenceId`, and `exdates` are also available on this type (see [Recurring Events](/docs/plugins/recurrence)).
 
 ### Event Properties Explained
 
@@ -777,8 +808,8 @@ interface CalendarEvent {
 
 - `id` - Must be unique across all events. Used for drag-and-drop and event updates.
 - `title` - The text displayed on the event in the calendar.
-- `start` - JavaScript Date object representing when the event begins.
-- `end` - JavaScript Date object representing when the event ends.
+- `start` - When the event begins. Pass a `Dayjs`, a `Date`, or an ISO string.
+- `end` - When the event ends. Pass a `Dayjs`, a `Date`, or an ISO string.
 
 #### Optional Properties
 

--- a/apps/website/src/content/docs/components/resource-calendar.mdx
+++ b/apps/website/src/content/docs/components/resource-calendar.mdx
@@ -6,7 +6,18 @@ slug: docs/components/resource-calendar
 
 A powerful calendar component for visualizing and managing events across multiple resources like rooms, equipment, or team members.
 
-The Resource Calendar extends the standard calendar with resource-based event organization. Events are displayed in horizontal rows where each row represents a resource (person, room, equipment, etc.). It supports all standard calendar features including drag-and-drop, recurring events, and internationalization.
+The Resource Calendar extends the standard calendar with resource-based event organization. Events are displayed in rows (or columns) where each represents a resource (person, room, equipment, etc.). It supports all standard calendar features including drag-and-drop, recurring events, and internationalization.
+
+:::caution[v2: use `IlamyCalendar` with `resources`]
+In v2 the resource axis is built into `IlamyCalendar`: pass `resources`, `orientation`, `renderResource`, and `weekViewGranularity` directly to it. The dedicated `IlamyResourceCalendar` component still works as a **deprecated alias** (it will be removed in the next major), so the examples below use `IlamyCalendar`.
+
+```tsx
+// Before (v1)
+<IlamyResourceCalendar resources={rooms} orientation="vertical" events={events} />
+// After (v2)
+<IlamyCalendar resources={rooms} orientation="vertical" events={events} />
+```
+:::
 
 :::tip[Try it out]
 Visit the [interactive demo](/demo) and toggle to "Resource Calendar" mode to see it in action!
@@ -17,9 +28,9 @@ Visit the [interactive demo](/demo) and toggle to "Resource Calendar" mode to se
 ### Simple Resource Calendar
 
 ```tsx
-import { IlamyResourceCalendar } from '@ilamy/calendar';
+import { IlamyCalendar } from '@ilamy/calendar';
 import type { Resource, CalendarEvent } from '@ilamy/calendar';
-import dayjs from 'dayjs';
+import { dayjs } from '@ilamy/calendar';
 
 const resources: Resource[] = [
   {
@@ -49,7 +60,7 @@ const events: CalendarEvent[] = [
 
 function App() {
   return (
-    <IlamyResourceCalendar
+    <IlamyCalendar
       resources={resources}
       events={events}
       firstDayOfWeek="sunday"
@@ -84,15 +95,13 @@ interface Resource {
   // Background color for resource (hex, rgb, or CSS class)
   backgroundColor?: string;
 
-  // Optional position for resource display order
-  position?: number;
-
   // Optional business hours specific to this resource
   businessHours?: BusinessHours | BusinessHours[];
 
   // Custom metadata (e.g., avatar URLs, roles, departments)
-  // Accessible in custom resource renderers via renderResource
-  data?: Record<string, any>;
+  // Accessible in custom resource renderers via renderResource.
+  // Typed Record<string, unknown> in v2 — narrow or cast when reading.
+  data?: Record<string, unknown>;
 }
 ```
 
@@ -106,7 +115,7 @@ const resources = [
   { id: 'room-a', title: 'Room A', data: { capacity: 10, floor: 2 } },
 ];
 
-<IlamyResourceCalendar
+<IlamyCalendar
   resources={resources}
   renderResource={(resource) => (
     <div>
@@ -188,7 +197,7 @@ const event: CalendarEvent = {
 
 ## Props
 
-The IlamyResourceCalendar component extends all props from [IlamyCalendar](/docs/components/calendar) (including `locale`, `timezone`, `timeFormat`, etc.) with resource-specific additions below.
+These resource props are part of [IlamyCalendar](/docs/components/calendar)'s prop set (alongside `locale`, `timezone`, `timeFormat`, etc.); they take effect once `resources` is set.
 
 ### Resource-Specific Props
 
@@ -206,10 +215,10 @@ The IlamyResourceCalendar component extends all props from [IlamyCalendar](/docs
 ### Room Booking System
 
 ```tsx title="Conference Room Booking"
-import { IlamyResourceCalendar } from '@ilamy/calendar';
+import { IlamyCalendar } from '@ilamy/calendar';
 import type { CalendarEvent, CellInfo } from '@ilamy/calendar';
 import { useState } from 'react';
-import dayjs from 'dayjs';
+import { dayjs } from '@ilamy/calendar';
 
 const RoomBookingCalendar = () => {
   const [events, setEvents] = useState<CalendarEvent[]>([]);
@@ -259,7 +268,7 @@ const RoomBookingCalendar = () => {
   };
 
   return (
-    <IlamyResourceCalendar
+    <IlamyCalendar
       resources={rooms}
       events={events}
       initialView="week"
@@ -302,7 +311,7 @@ const IconResourceRenderer = (resource: Resource) => {
 
 function App() {
   return (
-    <IlamyResourceCalendar
+    <IlamyCalendar
       resources={resources}
       events={events}
       renderResource={IconResourceRenderer}
@@ -367,7 +376,7 @@ const unavailable = {
   'conf-a': [dayjs('2026-06-10')], // Room A out for maintenance
 };
 
-<IlamyResourceCalendar
+<IlamyCalendar
   resources={rooms}
   events={events}
   isCellDisabled={(info) => {
@@ -415,7 +424,7 @@ The resource week view supports two density modes via the `weekViewGranularity` 
 ### Hourly vs Daily — when to pick which
 
 ```tsx title="Hourly (default) — room-booking style"
-<IlamyResourceCalendar
+<IlamyCalendar
   resources={rooms}
   events={events}
   initialView="week"
@@ -424,7 +433,7 @@ The resource week view supports two density modes via the `weekViewGranularity` 
 ```
 
 ```tsx title="Daily — team-availability style"
-<IlamyResourceCalendar
+<IlamyCalendar
   resources={teamMembers}
   events={availabilityEvents}
   initialView="week"
@@ -446,7 +455,7 @@ The resource week view supports two density modes via the `weekViewGranularity` 
 
 ### Resource Organization
 - Use meaningful resource IDs (e.g., 'room-a', 'john-doe')
-- Set position property to control display order
+- Control display order by ordering the `resources` array itself
 - Group related resources by type
 - Include capacity info in resource titles when relevant
 

--- a/apps/website/src/content/docs/components/use-ilamy-calendar-context.mdx
+++ b/apps/website/src/content/docs/components/use-ilamy-calendar-context.mdx
@@ -4,7 +4,9 @@ description: Access calendar and resource calendar state and methods with the us
 slug: docs/components/use-ilamy-calendar-context
 ---
 
-A React hook for accessing calendar context and controlling calendar state programmatically. Works with both `IlamyCalendar` and `IlamyResourceCalendar` — when used inside a resource calendar, additional resource-specific properties are available.
+A React hook for accessing calendar context and controlling calendar state programmatically. It returns the `IlamyCalendarApi` object.
+
+The API is unified: the same shape is returned whether or not the calendar has resources. On a calendar without resources, `resources` is simply an empty array and `getEventsForResource` filters by the events' own `resourceId` / `resourceIds`. There is no separate resource-calendar return type.
 
 ## Basic Usage
 
@@ -49,43 +51,64 @@ function CustomEvent(event) {
 />
 ```
 
-## Return Values
+## Return Values (`IlamyCalendarApi`)
 
 The hook returns an object with the following properties and methods:
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `currentDate` | `dayjs.Dayjs` | The currently displayed date/month in the calendar view |
-| `view` | `'month' \| 'week' \| 'day' \| 'year'` | The current calendar view mode |
-| `events` | `CalendarEvent[]` | Array of all calendar events |
+| `currentDate` | `Dayjs` | The currently displayed date/month in the calendar view |
+| `view` | `CalendarView` (`string`) | The current view name. In v2 `CalendarView` is `string` so plugins can register extra views |
+| `events` | `CalendarEvent[]` | Expanded events for the current view (recurring instances included when the recurrence plugin is registered) |
+| `rawEvents` | `CalendarEvent[]` | The unexpanded source events as passed in. Use this to find a base recurring series by `uid` |
+| `resources` | `Resource[]` | Resources on the calendar. Empty array when none are set |
 | `isEventFormOpen` | `boolean` | Whether the event form modal is currently open |
 | `selectedEvent` | `CalendarEvent \| null` | The currently selected event, if any |
-| `selectedDate` | `Date \| null` | The currently selected date, if any |
-| `firstDayOfWeek` | `WeekDays` | The first day of the week setting |
-| `setCurrentDate` | `(date: dayjs.Dayjs) => void` | Navigate to a specific date/month |
-| `selectDate` | `(date: Date) => void` | Select a specific date |
-| `setView` | `(view: CalendarView) => void` | Change the calendar view mode |
-| `nextPeriod` | `() => void` | Navigate to the next period (month/week/day) |
-| `prevPeriod` | `() => void` | Navigate to the previous period (month/week/day) |
+| `selectedDate` | `Dayjs \| null` | The currently selected date, if any |
+| `firstDayOfWeek` | `number` | The first day of the week (0 = Sunday) |
+| `setCurrentDate` | `(date: Dayjs) => void` | Navigate to a specific date/month |
+| `selectDate` | `(date: Dayjs) => void` | Select a specific date |
+| `setView` | `(view: CalendarView) => void` | Change the current view |
+| `nextPeriod` | `() => void` | Navigate to the next period |
+| `prevPeriod` | `() => void` | Navigate to the previous period |
 | `today` | `() => void` | Navigate to today's date |
 | `addEvent` | `(event: CalendarEvent) => void` | Add a new event to the calendar |
-| `updateEvent` | `(id: string, updates: Partial<CalendarEvent>) => void` | Update an existing event |
-| `deleteEvent` | `(id: string) => void` | Delete an event from the calendar |
-| `openEventForm` | `(eventData?: Partial<CalendarEvent>) => void` | Open the event form modal with optional pre-populated data |
+| `updateEvent` | `(id: string \| number, updates: Partial<CalendarEvent>) => void` | Update an existing event |
+| `deleteEvent` | `(id: string \| number) => void` | Delete an event from the calendar |
+| `openEventForm` | `(eventData?: OpenEventFormInput) => void` | Open the event form modal with optional pre-populated data |
 | `closeEventForm` | `() => void` | Close the event form modal |
+| `onEventClick` | `(event: CalendarEvent) => void` | Run the calendar's event-click flow for an event |
+| `getEventsForResource` | `(resourceId: string \| number) => CalendarEvent[]` | Events for a resource. Always defined; filters by `resourceId` / `resourceIds` |
+| `getEventsForDateRange` | `(start: Dayjs, end: Dayjs) => CalendarEvent[]` | Events overlapping a date range |
+| `t` | `TranslatorFunction` | Translate a key with the active translations |
+| `timeFormat` | `TimeFormat` | `'12-hour'` or `'24-hour'` |
+| `timezone` | `string \| undefined` | The configured timezone, if any |
+| `currentLocale` | `string` | The active dayjs locale |
+| `businessHours` | `BusinessHours \| BusinessHours[] \| undefined` | The configured business hours |
+| `getViews` | `() => PluginView[]` | All registered views (built-in plus plugin) |
 
-## Resource Calendar
+### Scoped mutations (recurrence)
 
-When used inside `IlamyResourceCalendar`, the hook returns all the properties above plus resource-specific additions.
+`applyScopedEdit(event, updates, scope)` and `applyScopedDelete(event, scope)` apply an edit/delete with a scope (this / this-and-following / all) routed to the owning plugin. The `scope` value is produced by the recurrence plugin's mutation-scope dialog and is passed back automatically by the host's built-in scoped-mutation flow, so most apps never call these directly.
 
-### Resource-Specific Return Values
+:::note[Renamed in v2]
+The old `updateRecurringEvent` and `deleteRecurringEvent` are replaced by `applyScopedEdit` / `applyScopedDelete`. `findParentRecurringEvent` was removed — find the base series via `rawEvents` instead:
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `resources` | `Resource[]` | Array of all resources in the calendar |
-| `getResourceEvents` | `(resourceId: string \| number) => CalendarEvent[]` | Get all events for a specific resource |
+```ts
+const { rawEvents } = useIlamyCalendarContext();
+const baseEvent = rawEvents.find(
+  (e) => e.uid === instance.uid && e.rrule !== undefined
+);
+```
+:::
 
-### Resource Calendar Usage
+The API also exposes lower-level plugin-routing helpers — `getEventManager`, `renderSlot`, `collect`, and `renderCurrentTimeIndicator` — used internally by plugins; most consumers don't need them.
+
+## Resources
+
+`resources` and `getEventsForResource` are always available. Set the `resources` prop on `IlamyCalendar` to render a resource calendar.
+
+### Resource Usage
 
 ```tsx title="Via headerComponent"
 import { useIlamyCalendarContext } from '@ilamy/calendar';
@@ -103,7 +126,7 @@ function CustomHeader() {
   );
 }
 
-<IlamyResourceCalendar
+<IlamyCalendar
   resources={resources}
   events={events}
   headerComponent={<CustomHeader />}
@@ -114,9 +137,9 @@ function CustomHeader() {
 
 ```tsx title="Show Resource Booking Stats"
 function ResourceStats({ resourceId }) {
-  const { getResourceEvents, currentDate } = useIlamyCalendarContext();
+  const { getEventsForResource, currentDate } = useIlamyCalendarContext();
 
-  const events = getResourceEvents(resourceId);
+  const events = getEventsForResource(resourceId);
   const todayEvents = events.filter(event =>
     event.start.isSame(currentDate, 'day')
   );
@@ -129,7 +152,7 @@ function ResourceStats({ resourceId }) {
   );
 }
 
-<IlamyResourceCalendar
+<IlamyCalendar
   resources={resources}
   events={events}
   renderResource={(resource) => (
@@ -167,7 +190,7 @@ function ResourceActions({ resource }) {
   );
 }
 
-<IlamyResourceCalendar
+<IlamyCalendar
   resources={resources}
   events={events}
   renderResource={(resource) => <ResourceActions resource={resource} />}
@@ -176,7 +199,7 @@ function ResourceActions({ resource }) {
 
 ## Error Handling
 
-The hook will throw an error if used outside of the calendar context. Since `IlamyCalendar` and `IlamyResourceCalendar` do not accept children, you must use this hook in descendant components that are rendered through props like `headerComponent`, `renderEvent`, or `renderResource`.
+The hook will throw an error if used outside of the calendar context. Since `IlamyCalendar` does not accept children, you must use this hook in descendant components that are rendered through props like `headerComponent`, `renderEvent`, or `renderResource`.
 
 ```tsx title="Context Usage"
 // ❌ This will throw an error

--- a/apps/website/src/content/docs/features/internationalization.mdx
+++ b/apps/website/src/content/docs/features/internationalization.mdx
@@ -188,15 +188,9 @@ const myTranslator = (key: TranslationKey) => {
 TypeScript type definitions for internationalization features.
 
 ```typescript title="Internationalization Types"
-// Translations object interface (simplified - see TranslationKey for complete list)
-interface Translations {
-  today: string;
-  month: string;
-  week: string;
-  day: string;
-  year: string;
-  // ... many more keys (see TranslationKey type)
-}
+// In v2 `Translations` is a derived type alias (not an interface): every key
+// from the canonical English dictionary, mapped to a string.
+type Translations = Record<keyof typeof defaultTranslations, string>;
 
 // Translation key type (exported from package)
 type TranslationKey = keyof Translations;

--- a/apps/website/src/content/docs/getting-started/usage.mdx
+++ b/apps/website/src/content/docs/getting-started/usage.mdx
@@ -62,4 +62,22 @@ Once you've installed the package, follow these steps to configure and use the c
    }
    ```
 
+4. ### Add plugins (optional)
+
+   The v2 core ships **no plugins** by default. Capabilities like recurring events and the agenda view are opt-in: import them from their subpath and register them via the `plugins` prop. Skip this step if you don't need them.
+
+   ```tsx title="MyCalendar.tsx"
+   import { IlamyCalendar } from '@ilamy/calendar';
+   import { recurrencePlugin } from '@ilamy/calendar/plugins/recurrence';
+
+   export default function MyCalendar() {
+     return (
+       <div className="p-6">
+         {/* recurrencePlugin expands events that have an `rrule` */}
+         <IlamyCalendar plugins={[recurrencePlugin()]} />
+       </div>
+     );
+   }
+   ```
+
 </Steps>

--- a/apps/website/src/content/docs/help/faq.mdx
+++ b/apps/website/src/content/docs/help/faq.mdx
@@ -115,7 +115,7 @@ Yes, ilamy Calendar includes built-in iCalendar export functionality. See the [i
 
 ### Does it support recurring events?
 
-Yes, ilamy Calendar fully supports recurring events with RRULE patterns. See the [recurrence guide](/docs/features/recurrence) for details.
+Yes, ilamy Calendar fully supports recurring events with RRULE patterns. See the [recurrence guide](/docs/plugins/recurrence) for details.
 
 ### Can I use custom fonts?
 

--- a/apps/website/src/content/docs/help/support.mdx
+++ b/apps/website/src/content/docs/help/support.mdx
@@ -10,16 +10,16 @@ Get help and support for ilamy Calendar.
 
 Join our community on GitHub for discussions, bug reports, and feature requests.
 
-[Visit GitHub Repository →](https://github.com/ilamy-soft/ilamy-calendar)
+[Visit GitHub Repository →](https://github.com/kcsujeet/ilamy-calendar)
 
 ## Documentation
 
 Browse through our comprehensive documentation to find answers to common questions.
 
-[Read Documentation →](/docs/getting-started/overview)
+[Read Documentation →](/docs/introduction)
 
 ## Report Issues
 
 Found a bug or have a feature request? Please create an issue on GitHub.
 
-[Report Issue →](https://github.com/ilamy-soft/ilamy-calendar/issues)
+[Report Issue →](https://github.com/kcsujeet/ilamy-calendar/issues)

--- a/apps/website/src/content/docs/plugins/agenda.mdx
+++ b/apps/website/src/content/docs/plugins/agenda.mdx
@@ -1,0 +1,71 @@
+---
+title: Agenda Plugin
+description: Add an agenda (upcoming-events list) view scoped to a configurable date window.
+slug: docs/plugins/agenda
+---
+
+The agenda plugin adds an **agenda view** — a chronological, grouped-by-day list of the events in a date window. It is an opt-in plugin: the core ships no views beyond month, week, day, and year, so you register it through the `plugins` prop.
+
+## Installation
+
+Import `agendaPlugin` from the `@ilamy/calendar/plugins/agenda` subpath and pass it to `plugins`:
+
+```tsx
+import { IlamyCalendar } from '@ilamy/calendar';
+import { agendaPlugin } from '@ilamy/calendar/plugins/agenda';
+
+export default function MyCalendar() {
+  return (
+    <IlamyCalendar
+      events={events}
+      plugins={[agendaPlugin({ window: 'week' })]}
+    />
+  );
+}
+```
+
+Registering the plugin adds an **Agenda** entry to the view switcher. You can also open it programmatically with `setView('agenda')` from [`useIlamyCalendarContext`](/docs/components/use-ilamy-calendar-context), or make it the initial view with `initialView="agenda"`.
+
+## Options
+
+```ts
+agendaPlugin(options?: { window?: AgendaWindow })
+
+type AgendaWindow = 'day' | 'week' | 'month' | number
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `window` | `AgendaWindow` | `'month'` | The date window the agenda lists and that prev/next step over. |
+
+How `window` is interpreted:
+
+- **A named period** (`'day'`, `'week'`, `'month'`) is the calendar period *containing* the current date. It can include earlier days of that period and aligns with the matching grid view and header label.
+- **A number** is a rolling window of that many days starting *at* the current date and counting forward (e.g. `window={14}` lists the next 14 days).
+
+```tsx
+// The current calendar month
+<IlamyCalendar events={events} plugins={[agendaPlugin({ window: 'month' })]} />
+
+// A rolling 14-day window from today
+<IlamyCalendar events={events} plugins={[agendaPlugin({ window: 14 })]} />
+```
+
+## Combining with other plugins
+
+Plugins compose — pass them all in the `plugins` array. Register the [recurrence plugin](/docs/plugins/recurrence) alongside the agenda plugin and recurring instances appear in the agenda list:
+
+```tsx
+import { recurrencePlugin } from '@ilamy/calendar/plugins/recurrence';
+import { agendaPlugin } from '@ilamy/calendar/plugins/agenda';
+
+<IlamyCalendar
+  events={events}
+  plugins={[recurrencePlugin(), agendaPlugin({ window: 'week' })]}
+/>
+```
+
+## Notes
+
+- The agenda view does not support the resource axis. On a calendar with `resources` set, it is hidden from the view switcher.
+- Prev/next navigation steps by the configured window (a named period steps one period; a numeric window steps by that many days).

--- a/apps/website/src/content/docs/plugins/recurrence.mdx
+++ b/apps/website/src/content/docs/plugins/recurrence.mdx
@@ -1,7 +1,7 @@
 ---
-title: Recurring Events
+title: Recurrence Plugin
 description: Create and manage repeating events with powerful RRULE-based recurrence patterns following the iCalendar specification.
-slug: docs/features/recurrence
+slug: docs/plugins/recurrence
 ---
 
 Create and manage repeating events with powerful RRULE-based recurrence patterns following the iCalendar specification.
@@ -9,6 +9,19 @@ Create and manage repeating events with powerful RRULE-based recurrence patterns
 The recurrence system in ilamy Calendar supports creating repeating events using RRULE (Recurrence Rule) patterns based on the iCalendar RFC 5545 specification. Under the hood, it uses the powerful [rrule.js](https://github.com/jakubroztocil/rrule) library to generate recurring event instances, ensuring robust and reliable recurrence handling.
 
 **RFC 5545 Compliant:** The recurrence system uses the industry-standard RRULE format powered by rrule.js, ensuring compatibility with other calendar applications when exporting.
+
+:::caution[Recurrence is opt-in in v2]
+In v2 the core ships zero plugins. Recurring events are **not** expanded unless you register the recurrence plugin. Import it from the `@ilamy/calendar/plugins/recurrence` subpath and pass it via the `plugins` prop:
+
+```tsx
+import { IlamyCalendar } from '@ilamy/calendar'
+import { recurrencePlugin } from '@ilamy/calendar/plugins/recurrence'
+
+<IlamyCalendar events={events} plugins={[recurrencePlugin()]} />
+```
+
+Importing from this subpath also re-adds the `rrule`, `recurrenceId`, and `exdates` fields to `CalendarEvent` via TypeScript declaration merging. Without it, TypeScript reports `Property 'rrule' does not exist on type 'CalendarEvent'`.
+:::
 
 ## Key Features
 
@@ -35,8 +48,8 @@ The recurrence system in ilamy Calendar supports creating repeating events using
 Create a recurring event by adding an `rrule` property to your event object:
 
 ```tsx
-import { RRule } from 'rrule'
-import dayjs from 'dayjs'
+import { dayjs } from '@ilamy/calendar'
+import { RRule } from '@ilamy/calendar/plugins/recurrence'
 
 const weeklyMeeting = {
   id: 'weekly-standup',
@@ -103,13 +116,14 @@ rrule: {
 
 ## Instance Generation
 
-### Automatic Generation
+### Generation (with the recurrence plugin)
 
-The calendar automatically generates recurring event instances within the current view range using rrule.js internally. This happens transparently when navigating between different calendar views:
+When the recurrence plugin is registered, the calendar generates recurring event instances within the current view range using rrule.js internally. This happens transparently when navigating between different calendar views. Without the plugin, a base event with an `rrule` is rendered as a single event and never expanded.
 
 ```tsx
-// The calendar automatically generates instances
-// when you provide a base recurring event
+import { IlamyCalendar } from '@ilamy/calendar'
+import { recurrencePlugin } from '@ilamy/calendar/plugins/recurrence'
+
 const events = [
   {
     id: 'weekly-standup',
@@ -125,8 +139,8 @@ const events = [
   }
 ]
 
-// Pass this to IlamyCalendar and instances
-// will be generated automatically for the current view
+// Register the plugin so instances are generated for the current view
+<IlamyCalendar events={events} plugins={[recurrencePlugin()]} />
 ```
 
 ### Handling Overrides

--- a/docs/logs/2026-06-15.md
+++ b/docs/logs/2026-06-15.md
@@ -6,12 +6,20 @@
 - **[calendar]**: Added a regression test guarding the resource month (horizontal) today highlight — there was no test for it, which is why it regressed/was-missing. The resource week header was already covered; the month header was not.
 - **[ui]**: `DayLabel` now exposes `data-today="true"` on its wrapper when `today` is set, as a stable styling/selection hook (and a non-brittle test target — avoids asserting `bg-primary` classes in JSDOM). `DayLabel` is the single source of truth for today-highlighting, so this hook applies across all views/plugins.
 - **[calendar]**: Month view day number now aligns top-left instead of top-center. Passed `className="items-start"` to the grid-cell `DayLabel` (twMerge overrides its default `items-center`). Only the regular month grid sets `showDayNumber`, so other views are unaffected.
+- **[website docs]**: Updated docs to v2. Audited each page against `docs/migration-v2.md` and the actual public API (`packages/calendar/src/index.ts`, `IlamyCalendarApi`, types, recurrence/agenda subpath exports). Fixes: plugin opt-in model (`plugins={[recurrencePlugin()]}`), recurrence/agenda subpath imports, `IlamyResourceCalendar` documented as deprecated alias (examples switched to `IlamyCalendar resources={...}`), `IlamyCalendarApi` return-values table corrected (`getEventsForResource`, `Dayjs` types, `view: string`, `rawEvents`, `applyScopedEdit/Delete`, removed `findParentRecurringEvent`/`updateRecurringEvent`/`deleteRecurringEvent`), `Resource.position` removed, `data: Record<string, unknown>`, `Translations` as derived type alias, added a `## Plugins` section to calendar.mdx.
+- **[website docs]**: New **Plugins** sidebar section. Moved `features/recurrence.mdx` → `plugins/recurrence.mdx` (now `/docs/plugins/recurrence`) and added a new `plugins/agenda.mdx` documenting `agendaPlugin({ window })` (`AgendaWindow = 'day' | 'week' | 'month' | number`, default `'month'`; resource-incapable). Repointed internal links; old `/docs/features/recurrence` URL intentionally not preserved. Website build passes (24 pages).
 
 ## Files Modified
 
 - `packages/ui/src/components/day-label.tsx` - Added `data-today` attribute on the wrapper + doc note on the `today` prop.
 - `packages/calendar/src/components/grid-cell.tsx` - Month day number aligned top-left via `items-start` on the `DayLabel`.
 - `packages/calendar/src/features/calendar/components/views/month.test.tsx` - New `ResourceMonthHorizontal` regression test: renders the horizontal resource month and asserts exactly one `[data-today="true"]` cell, showing today's day number.
+- `apps/website/src/content/docs/{components/calendar,components/resource-calendar,components/use-ilamy-calendar-context,features/internationalization,getting-started/usage}.mdx` - v2 doc updates (see [website docs] above).
+- `apps/website/src/content/docs/plugins/recurrence.mdx` - moved from `features/recurrence.mdx`; retitled "Recurrence Plugin"; opt-in plugin + subpath import updates.
+- `apps/website/src/content/docs/plugins/agenda.mdx` - new agenda plugin page.
+- `apps/website/astro.config.mjs` - new Plugins sidebar group; removed Recurrence from Features.
+- `apps/website/src/content/docs/help/support.mdx` - verification-pass fixes (both pre-existing, not v2): broken link `/docs/getting-started/overview` → `/docs/introduction`, and stale GitHub URLs `ilamy-soft/ilamy-calendar` → `kcsujeet/ilamy-calendar` (matches package.json + every other ref).
+- `apps/website/src/content/docs/help/faq.mdx` - repointed the recurrence link to `/docs/plugins/recurrence`.
 
 ## Notes
 


### PR DESCRIPTION
## What

Brings the website docs up to date with the v2 changes and adds a dedicated **Plugins** section.

## Corrected pages (audited against `docs/migration-v2.md` + the real public API)

- **`components/use-ilamy-calendar-context.mdx`** — rebuilt the return-values table to match `IlamyCalendarApi`: `getResourceEvents`→`getEventsForResource`, `Date`→`Dayjs` (`selectedDate`/`selectDate`), `view: string`, added `rawEvents`/`getEventsForDateRange`/`applyScopedEdit`/`applyScopedDelete`/`t`/`getViews`/etc.; "Renamed in v2" note for the removed `updateRecurringEvent`/`deleteRecurringEvent`/`findParentRecurringEvent`; dropped the false "resource calendars return extra members" framing (API is unified).
- **`components/calendar.mdx`** — new `## Plugins` section, added `plugins`/`resources`/`orientation`/`renderResource`/`weekViewGranularity` prop rows, corrected `CalendarEvent` input types (`Dayjs | Date | string`, `id: string|number`, `data: Record<string, unknown>`), `CalendarView` is `string`. Also fixed two pre-existing missing commas in an example.
- **`components/resource-calendar.mdx`** — deprecation callout (examples now use `<IlamyCalendar resources={...}>`), removed `Resource.position`, `data: Record<string, unknown>`, fixed the ordering best-practice.
- **`features/internationalization.mdx`** — `Translations` is a derived type alias, not an interface.
- **`getting-started/usage.mdx`** — added an opt-in "Add plugins" step.

## New Plugins section

- Moved `features/recurrence.mdx` → **`plugins/recurrence.mdx`** (`/docs/plugins/recurrence`), retitled "Recurrence Plugin".
- Added **`plugins/agenda.mdx`** documenting `agendaPlugin({ window })` (`AgendaWindow = 'day' | 'week' | 'month' | number`, default `'month'`; resource-incapable), verified against source.
- `astro.config.mjs`: new **Plugins** sidebar group; removed Recurrence from Features.

## Incidental fixes found during review (pre-existing, not v2)

- `help/support.mdx`: broken link `/docs/getting-started/overview` → `/docs/introduction`; stale GitHub URLs `ilamy-soft/...` → `kcsujeet/...` (matches `package.json`).
- `help/faq.mdx`: recurrence link repointed to the moved page.

## Verification

- Website build passes (24 pages); zero broken internal links.
- Every API claim cross-checked against source (`IlamyCalendarApi`, agenda/recurrence subpath exports, `Resource`/`CalendarEvent` types, `firstDayOfWeek` numbering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)