### PR TITLE
feat(calendar): add getCellClassName prop for customizable cell styling

### DIFF
--- a/docs/logs/2026-06-17.md
+++ b/docs/logs/2026-06-17.md
@@ -1,0 +1,18 @@
+# Development Log - 2026-06-17
+
+## Changes
+
+- **[calendar]**: Added `getCellClassName` prop on `IlamyCalendarProps` for visual-only cell styling (e.g. unavailability periods). Unlike `isCellDisabled`, styled cells remain clickable and accept drag-drops. Applied centrally in `DroppableCell` so all views (month, week, day, resource) pick it up.
+
+## Files Modified
+
+- `packages/calendar/src/features/calendar/types/index.ts` - Added `getCellClassName?: (info: CellInfo) => string | undefined` to `IlamyCalendarProps`.
+- `packages/calendar/src/features/calendar/contexts/calendar-context/context.ts` - Threaded `getCellClassName` through context type.
+- `packages/calendar/src/features/calendar/contexts/calendar-context/provider.tsx` - Passed `getCellClassName` from provider props into context value.
+- `packages/calendar/src/components/droppable-cell.tsx` - Applied `getCellClassName(cellInfo)` to the cell `className`.
+- `packages/calendar/src/components/droppable-cell.test.tsx` - Unit tests for class application, click behavior, and `CellInfo` payload.
+- `packages/calendar/src/features/calendar/components/ilamy-calendar.test.tsx` - Integration test in month view.
+
+## Notes
+
+Use `getCellClassName` for visual unavailability; use `isCellDisabled` when event creation should be blocked.

--- a/packages/calendar/src/components/droppable-cell.test.tsx
+++ b/packages/calendar/src/components/droppable-cell.test.tsx
@@ -160,3 +160,68 @@ describe('DroppableCell isCellDisabled (issue #79)', () => {
 		expect(received?.resource?.id).toBe('room-a')
 	})
 })
+
+describe('DroppableCell getCellClassName', () => {
+	beforeEach(() => {
+		cleanup()
+	})
+
+	const renderCell = (opts: {
+		getCellClassName?: (info: CellInfo) => string
+		onCellClick?: (info: CellInfo) => void
+	}) => {
+		return render(
+			<CalendarProvider
+				dayMaxEvents={3}
+				getCellClassName={opts.getCellClassName}
+				initialDate={initialDate}
+				initialView="month"
+				onCellClick={opts.onCellClick}
+			>
+				<DroppableCell
+					data-testid="cell"
+					date={initialDate}
+					id="test-cell"
+					type="day-cell"
+				/>
+			</CalendarProvider>
+		)
+	}
+
+	test('applies the class returned by getCellClassName', () => {
+		renderCell({
+			getCellClassName: () => 'bg-amber-100',
+		})
+
+		expect(screen.getByTestId('cell')).toHaveClass('bg-amber-100')
+	})
+
+	test('does not block onCellClick when only getCellClassName marks a cell', () => {
+		const onCellClick = mock()
+		renderCell({
+			getCellClassName: () => 'bg-amber-100',
+			onCellClick,
+		})
+
+		fireEvent.click(screen.getByTestId('cell'))
+
+		expect(onCellClick).toHaveBeenCalledTimes(1)
+		expect(screen.getByTestId('cell').getAttribute('data-disabled')).toBe(
+			'false'
+		)
+	})
+
+	test('passes the cell start/end range to getCellClassName', () => {
+		let received: CellInfo | undefined
+		renderCell({
+			getCellClassName: (info) => {
+				received = info
+				return ''
+			},
+		})
+
+		expect(received?.start.toISOString()).toBe('2025-01-01T00:00:00.000Z')
+		expect(received?.end.hour()).toBe(23)
+		expect(received?.end.minute()).toBe(59)
+	})
+})

--- a/packages/calendar/src/components/droppable-cell.tsx
+++ b/packages/calendar/src/components/droppable-cell.tsx
@@ -58,6 +58,7 @@ export function DroppableCell({
 	const {
 		onCellClick,
 		isCellDisabled,
+		getCellClassName,
 		getResourceById,
 		disableDragAndDrop,
 		disableCellClick,
@@ -90,6 +91,7 @@ export function DroppableCell({
 
 	const showDropHighlight = isOver && !disableDragAndDrop && !cellDisabled
 	const disabledClass = classesOverride?.disabledCell || DISABLED_CELL_CLASSNAME
+	const customClassName = getCellClassName?.(cellInfo)
 
 	return (
 		// biome-ignore lint/a11y/noStaticElementInteractions: The cell is interactive for event creation
@@ -98,6 +100,7 @@ export function DroppableCell({
 			className={cn(
 				'droppable-cell',
 				className,
+				customClassName,
 				showDropHighlight && 'bg-accent',
 				clickBlocked ? 'cursor-default' : 'cursor-pointer',
 				cellDisabled && disabledClass

--- a/packages/calendar/src/features/calendar/components/ilamy-calendar.test.tsx
+++ b/packages/calendar/src/features/calendar/components/ilamy-calendar.test.tsx
@@ -862,6 +862,33 @@ describe('IlamyCalendar', () => {
 		})
 	})
 
+	describe('getCellClassName', () => {
+		it('styles unavailable cells without blocking clicks in month view', () => {
+			const onCellClick = mock()
+			render(
+				<IlamyCalendar
+					events={[]}
+					getCellClassName={(info) =>
+						info.start.date() === 20 ? 'bg-amber-100' : ''
+					}
+					initialDate={dayjs('2025-01-15T00:00:00.000Z')}
+					initialView="month"
+					onCellClick={onCellClick}
+				/>
+			)
+
+			const styledCell = screen.getByTestId('day-cell-2025-01-20')
+			const plainCell = screen.getByTestId('day-cell-2025-01-15')
+
+			expect(styledCell).toHaveClass('bg-amber-100')
+			expect(plainCell).not.toHaveClass('bg-amber-100')
+			expect(styledCell.getAttribute('data-disabled')).toBe('false')
+
+			fireEvent.click(styledCell)
+			expect(onCellClick).toHaveBeenCalledTimes(1)
+		})
+	})
+
 	describe('isCellDisabled (issue #79)', () => {
 		it('disables the matching cell and blocks its click in month view', () => {
 			const onCellClick = mock()

--- a/packages/calendar/src/features/calendar/contexts/calendar-context/context.ts
+++ b/packages/calendar/src/features/calendar/contexts/calendar-context/context.ts
@@ -22,6 +22,7 @@ export interface CalendarContextType extends CalendarEngineReturn {
 	onEventClick: (event: CalendarEvent) => void
 	onCellClick: (info: CellInfo) => void
 	isCellDisabled?: (info: CellInfo) => boolean
+	getCellClassName?: (info: CellInfo) => string | undefined
 	locale?: string
 	timezone?: string
 	disableCellClick?: boolean

--- a/packages/calendar/src/features/calendar/contexts/calendar-context/provider.tsx
+++ b/packages/calendar/src/features/calendar/contexts/calendar-context/provider.tsx
@@ -33,6 +33,7 @@ export interface CalendarProviderProps {
 	onEventClick?: (event: CalendarEvent) => void
 	onCellClick?: (info: CellInfo) => void
 	isCellDisabled?: (info: CellInfo) => boolean
+	getCellClassName?: (info: CellInfo) => string
 	onViewChange?: (view: CalendarView) => void
 	onEventAdd?: (event: CalendarEvent) => void
 	onEventUpdate?: (event: CalendarEvent) => void
@@ -98,6 +99,7 @@ const useCalendarContextValue = (
 		onEventClick,
 		onCellClick,
 		isCellDisabled,
+		getCellClassName,
 		onViewChange,
 		onEventAdd,
 		onEventUpdate,
@@ -174,6 +176,7 @@ const useCalendarContextValue = (
 			onEventClick: handleEventClick,
 			onCellClick: handleDateClick,
 			isCellDisabled,
+			getCellClassName,
 			locale,
 			timezone,
 			disableCellClick,
@@ -202,6 +205,7 @@ const useCalendarContextValue = (
 		renderEvent,
 		renderResource,
 		isCellDisabled,
+		getCellClassName,
 		locale,
 		timezone,
 		disableCellClick,

--- a/packages/calendar/src/features/calendar/types/index.ts
+++ b/packages/calendar/src/features/calendar/types/index.ts
@@ -154,6 +154,12 @@ export interface IlamyCalendarProps {
 	 */
 	isCellDisabled?: (info: CellInfo) => boolean
 	/**
+	 * Returns extra CSS classes for a cell based on custom logic (unavailability
+	 * styling, on-call windows, etc.). Unlike `isCellDisabled`, this is purely
+	 * visual — cells remain clickable and accept drag-drops.
+	 */
+	getCellClassName?: (info: CellInfo) => string
+	/**
 	 * Callback when the calendar view changes (month, week, day, year).
 	 * Useful for syncing with external state or analytics.
 	 */


### PR DESCRIPTION
fixes #210 

Introduced a new `getCellClassName` prop in `IlamyCalendarProps` to allow for visual-only cell styling, enabling cells to remain clickable while applying custom classes. Updated relevant components and context to support this feature, along with unit and integration tests to ensure functionality.

## What changed?

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [ ] CI passes locally (`bun run ci`)
- [ ] Changes are tested
- [ ] Code follows project standards
