### PR TITLE
fix: resource picker missing on new event for calendar Resource

### DIFF
--- a/docs/logs/2026-06-18.md
+++ b/docs/logs/2026-06-18.md
@@ -1,0 +1,18 @@
+# Development Log - 2026-06-18
+
+## Changes
+
+- **[event-form]**: Added a resource selector to the event form when the calendar has a resource axis, so new events created via the header "New" button get a `resourceId` and appear on the resource view.
+- **[event-form]**: Hide the resource selector when the draft event already has a `resourceId` (e.g. grid cell click on a resource row).
+- **[event-form]**: Disable Create until a resource is picked when the selector is shown.
+
+## Files Modified
+
+- `packages/calendar/src/features/calendar/components/event-form/event-form.tsx` - Resource dropdown shown only when resource is unknown; disabled submit until selected
+- `packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx` - Resource selector visibility and submit tests
+- `packages/calendar/src/lib/translations/default.ts` - `selectResource` translation key
+
+## Notes
+
+- Cell clicks already passed `resourceId` into the draft event; the gap was the header add flow with no resource picker.
+- Submit requires an explicit resource choice only when the selector is shown (header "New").

--- a/packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx
+++ b/packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
-import type { CalendarEvent } from '@ilamy/types'
+import type { CalendarEvent, Resource } from '@ilamy/types'
 import dayjs from '@ilamy/utils/dayjs'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { CalendarProvider } from '@/features/calendar/contexts/calendar-context/provider'
@@ -431,6 +431,132 @@ describe('EventForm', () => {
 			titleInput.focus()
 
 			expect(document.activeElement).toBe(titleInput)
+		})
+	})
+
+	describe('Resource selector', () => {
+		const mockResources: Resource[] = [
+			{ id: 'room-a', title: 'Room A' },
+			{ id: 'room-b', title: 'Room B' },
+		]
+
+		const selectResource = (title: string) => {
+			fireEvent.click(screen.getByRole('combobox', { name: /resource/i }))
+			fireEvent.click(screen.getByRole('option', { name: title }))
+		}
+
+		it('does not render a resource selector without resources', () => {
+			renderEventForm({ ...defaultProps, selectedEvent: testNewEvent })
+
+			expect(
+				screen.queryByRole('combobox', { name: /resource/i })
+			).not.toBeInTheDocument()
+		})
+
+		it('renders a resource selector when resources are configured and no resource is known', () => {
+			renderEventForm(
+				{ ...defaultProps, selectedEvent: testNewEvent },
+				{ resources: mockResources }
+			)
+
+			expect(
+				screen.getByRole('combobox', { name: /resource/i })
+			).toBeInTheDocument()
+		})
+
+		it('hides the resource selector when resourceId is already known', () => {
+			renderEventForm(
+				{
+					...defaultProps,
+					selectedEvent: { ...testNewEvent, resourceId: 'room-b' },
+				},
+				{ resources: mockResources }
+			)
+
+			expect(
+				screen.queryByRole('combobox', { name: /resource/i })
+			).not.toBeInTheDocument()
+		})
+
+		it('keeps a known resourceId when creating from a resource grid cell', async () => {
+			renderEventForm(
+				{
+					...defaultProps,
+					selectedEvent: { ...testNewEvent, resourceId: 'room-b' },
+				},
+				{ resources: mockResources }
+			)
+
+			fireEvent.change(screen.getByPlaceholderText('Event title'), {
+				target: { value: 'Grid Event' },
+			})
+			fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+			await waitFor(() => {
+				expect(mockOnAdd).toHaveBeenCalledWith(
+					expect.objectContaining({
+						title: 'Grid Event',
+						resourceId: 'room-b',
+					})
+				)
+			})
+		})
+
+		it('disables create until a resource is selected', () => {
+			renderEventForm(
+				{ ...defaultProps, selectedEvent: testNewEvent },
+				{ resources: mockResources }
+			)
+
+			expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+		})
+
+		it('includes selected resourceId when creating a new event', async () => {
+			renderEventForm(
+				{ ...defaultProps, selectedEvent: testNewEvent },
+				{ resources: mockResources }
+			)
+
+			fireEvent.change(screen.getByPlaceholderText('Event title'), {
+				target: { value: 'Resource Event' },
+			})
+			selectResource('Room A')
+
+			fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+			await waitFor(() => {
+				expect(mockOnAdd).toHaveBeenCalledWith(
+					expect.objectContaining({
+						title: 'Resource Event',
+						resourceId: 'room-a',
+					})
+				)
+			})
+		})
+
+		it('preserves resourceId when editing an event with a known resource', async () => {
+			renderEventForm(
+				{
+					...defaultProps,
+					selectedEvent: { ...testEvent, resourceId: 'room-a' },
+				},
+				{ resources: mockResources }
+			)
+
+			expect(
+				screen.queryByRole('combobox', { name: /resource/i })
+			).not.toBeInTheDocument()
+
+			fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+			await waitFor(() => {
+				expect(mockOnUpdate).toHaveBeenCalledWith(
+					expect.objectContaining({
+						id: 'test-event-1',
+						resourceId: 'room-a',
+					})
+				)
+			})
 		})
 	})
 

--- a/packages/calendar/src/features/calendar/components/event-form/event-form.tsx
+++ b/packages/calendar/src/features/calendar/components/event-form/event-form.tsx
@@ -5,6 +5,13 @@ import { DialogFooter } from '@ilamy/ui/components/dialog'
 import { Input } from '@ilamy/ui/components/input'
 import { Label } from '@ilamy/ui/components/label'
 import { ScrollArea } from '@ilamy/ui/components/scroll-area'
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@ilamy/ui/components/select'
 import { cn } from '@ilamy/ui/lib/utils'
 import dayjs from '@ilamy/utils/dayjs'
 import type React from 'react'
@@ -106,17 +113,19 @@ export const EventForm: React.FC<EventFormProps> = ({
 		handleConfirm,
 	} = useScopedEventMutation(onClose)
 
-	const { t, timeFormat, getEventManager } = useSmartCalendarContext(
+	const { t, timeFormat, getEventManager, resources } = useSmartCalendarContext(
 		(context) => ({
 			t: context.t,
 			timeFormat: context.timeFormat,
 			getEventManager: context.getEventManager,
+			resources: context.resources ?? [],
 		})
 	)
 	// The selected event's fields, or the new-event defaults.
 	const {
 		id: selectedEventId,
 		resourceId,
+		resourceIds,
 		start = dayjs(),
 		end = dayjs().add(1, 'hour'),
 		allDay: initialAllDay = false,
@@ -126,7 +135,18 @@ export const EventForm: React.FC<EventFormProps> = ({
 		location: initialLocation = '',
 	} = selectedEvent ?? {}
 
-	const effectiveBusinessHours = useEffectiveBusinessHours(resourceId)
+	const hasResources = resources.length > 0
+	const initialSelectedResourceId = resourceId ?? resourceIds?.at(0)
+	const showResourceSelector =
+		hasResources && initialSelectedResourceId === undefined
+
+	const [selectedResourceId, setSelectedResourceId] = useState<
+		string | number | undefined
+	>(initialSelectedResourceId)
+
+	const effectiveResourceId = hasResources ? selectedResourceId : resourceId
+
+	const effectiveBusinessHours = useEffectiveBusinessHours(effectiveResourceId)
 
 	// Whether a plugin owns this event (gates the scoped edit/delete flow)
 	const eventIsOwned = Boolean(selectedEvent && getEventManager(selectedEvent))
@@ -207,8 +227,20 @@ export const EventForm: React.FC<EventFormProps> = ({
 		}
 	}, [isAllDay])
 
+	const resolveResourceId = (value: string): string | number => {
+		const resource = resources.find((item) => String(item.id) === value)
+		return resource?.id ?? value
+	}
+
+	const isResourceMissing =
+		showResourceSelector && selectedResourceId === undefined
+
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault()
+
+		if (isResourceMissing) {
+			return
+		}
 
 		const startDateTime = buildDateTime(startDate, startTime, isAllDay)
 		const endDateTime = buildEndDateTime(endDate, endTime, isAllDay)
@@ -218,7 +250,7 @@ export const EventForm: React.FC<EventFormProps> = ({
 			title: formValues.title,
 			start: startDateTime,
 			end: endDateTime,
-			resourceId,
+			resourceId: effectiveResourceId,
 			description: formValues.description,
 			location: formValues.location,
 			allDay: isAllDay,
@@ -231,6 +263,7 @@ export const EventForm: React.FC<EventFormProps> = ({
 				title: formValues.title,
 				start: startDateTime,
 				end: endDateTime,
+				resourceId: effectiveResourceId,
 				description: formValues.description,
 				location: formValues.location,
 				allDay: isAllDay,
@@ -287,6 +320,8 @@ export const EventForm: React.FC<EventFormProps> = ({
 		['endTime', 'end-time', endTime, handleEndTimeChange, endConstraints],
 	] as const
 
+	const resourceSelectValue = selectedResourceId?.toString()
+
 	return (
 		<>
 			<form className="flex flex-col flex-1 min-h-0" onSubmit={handleSubmit}>
@@ -307,6 +342,38 @@ export const EventForm: React.FC<EventFormProps> = ({
 							placeholder={t('eventDescriptionPlaceholder')}
 							value={formValues.description}
 						/>
+
+						{showResourceSelector && (
+							<div className="grid gap-1 sm:gap-2">
+								<Label className="text-xs sm:text-sm" htmlFor="resource">
+									{t('resource')}
+								</Label>
+								<Select
+									onValueChange={(value) =>
+										setSelectedResourceId(resolveResourceId(value))
+									}
+									value={resourceSelectValue}
+								>
+									<SelectTrigger
+										className="h-8 text-sm sm:h-9"
+										data-testid="resource-select"
+										id="resource"
+									>
+										<SelectValue placeholder={t('selectResource')} />
+									</SelectTrigger>
+									<SelectContent>
+										{resources.map((resource) => (
+											<SelectItem
+												key={String(resource.id)}
+												value={String(resource.id)}
+											>
+												{resource.title}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						)}
 
 						<div className="flex items-center space-x-2">
 							<Checkbox
@@ -409,7 +476,12 @@ export const EventForm: React.FC<EventFormProps> = ({
 						>
 							{t('cancel')}
 						</Button>
-						<Button className="flex-1 sm:flex-none" size="sm" type="submit">
+						<Button
+							className="flex-1 sm:flex-none"
+							disabled={isResourceMissing}
+							size="sm"
+							type="submit"
+						>
 							{selectedEventId ? t('update') : t('create')}
 						</Button>
 					</div>

--- a/packages/calendar/src/lib/translations/default.ts
+++ b/packages/calendar/src/lib/translations/default.ts
@@ -92,6 +92,7 @@ export const defaultTranslations = {
 	// Resource calendar
 	resources: 'Resources',
 	resource: 'Resource',
+	selectResource: 'Select a resource',
 	time: 'Time',
 	date: 'Date',
 	noResourcesVisible: 'No resources visible',


### PR DESCRIPTION
## What changed?

closes #212 
replace #213 closed by mistake

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [x] CI passes locally (`bun run ci`)
- [x] Changes are tested
- [ ] Code follows project standards
