### PR TITLE
docs(website): document drag-to-create, getCellClassName, headerClassName, orientation

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -77,6 +77,10 @@ export default defineConfig({
 					items: [
 						{ label: 'Recurrence', slug: 'docs/plugins/recurrence' },
 						{ label: 'Agenda', slug: 'docs/plugins/agenda' },
+						{
+							label: 'Drag to Create',
+							slug: 'docs/plugins/drag-to-create',
+						},
 					],
 				},
 				{

--- a/apps/website/src/content/docs/components/calendar.mdx
+++ b/apps/website/src/content/docs/components/calendar.mdx
@@ -90,6 +90,7 @@ The only valid import entry points are `@ilamy/calendar`, `@ilamy/calendar/plugi
 | `stickyViewHeader` | `boolean` | `true` | Whether to stick the view header to the top |
 | `viewHeaderClassName` | `string` | `''` | Custom class name for the view header |
 | `headerComponent` | `ReactNode` | `null` | Custom header component to render above the calendar |
+| `headerClassName` | `string` | `undefined` | Custom class name applied to the calendar header (the toolbar with navigation and view controls). |
 | `hideExportButton` | `boolean` | `false` | Hide the "Export" (.ics download) button in the calendar header. |
 | `renderCurrentTimeIndicator` | `(context: RenderCurrentTimeIndicatorProps) => ReactNode` | - | Custom function to render the current time indicator (line). |
 | `renderHour` | `(date: dayjs.Dayjs) => ReactNode` | - | Custom function to render hour labels in the time gutter of day and week views. Receives a Dayjs object for the hour. |
@@ -111,6 +112,7 @@ The only valid import entry points are `@ilamy/calendar`, `@ilamy/calendar/plugi
 | `onEventClick` | `(event: CalendarEvent) => void` | Called when an event is clicked |
 | `onCellClick` | `(info: CellInfo) => void` | Called when a date cell is clicked. Receives a CellInfo object with start, end, and optional resource (the full resource object in resource calendars). |
 | `isCellDisabled` | `(info: CellInfo) => boolean` | Return `true` to disable a cell: blocks event-creation clicks, rejects drops onto the cell, and grays it out. Composes with `businessHours` via OR (a cell is disabled if business hours OR `isCellDisabled` disables it). |
+| `getCellClassName` | `(info: CellInfo) => string` | Return extra CSS classes for a cell from custom logic (unavailability styling, on-call windows, etc.). Receives the same `CellInfo` as `onCellClick`. Unlike `isCellDisabled`, this is purely visual: cells stay clickable and keep accepting drops. Return `''` for cells you do not want to style. |
 | `onViewChange` | `(view: 'month' \| 'week' \| 'day' \| 'year') => void` | Called when the calendar view changes |
 | `onEventAdd` | `(event: CalendarEvent) => void` | Called when a new event is created |
 | `onEventUpdate` | `(event: CalendarEvent) => void` | Called when an existing event is updated |
@@ -923,7 +925,7 @@ const businessHours: BusinessHours[] = [
 
 ### CellInfo Interface
 
-Information passed to the `onCellClick` and `isCellDisabled` callbacks. Uses named properties for better extensibility and clarity.
+Information passed to the `onCellClick`, `isCellDisabled`, and `getCellClassName` callbacks. Uses named properties for better extensibility and clarity.
 
 ```typescript title="CellInfo Type Definition"
 interface CellInfo {
@@ -984,6 +986,23 @@ const isHoliday = (date: dayjs.Dayjs) =>
 <IlamyCalendar
   events={events}
   isCellDisabled={(info) => isHoliday(info.start)}
+/>
+```
+
+#### Styling Cells
+
+Use `getCellClassName` to add CSS classes to specific cells based on custom logic
+(unavailability styling, on-call windows, highlighting). Unlike `isCellDisabled`,
+this is purely visual: cells stay clickable and keep accepting drops. Return an
+empty string for cells you do not want to style.
+
+```typescript
+const isWeekend = (date: dayjs.Dayjs) =>
+  date.day() === 0 || date.day() === 6;
+
+<IlamyCalendar
+  events={events}
+  getCellClassName={(info) => (isWeekend(info.start) ? 'bg-amber-50' : '')}
 />
 ```
 

--- a/apps/website/src/content/docs/components/use-ilamy-calendar-context.mdx
+++ b/apps/website/src/content/docs/components/use-ilamy-calendar-context.mdx
@@ -62,6 +62,7 @@ The hook returns an object with the following properties and methods:
 | `events` | `CalendarEvent[]` | Expanded events for the current view (recurring instances included when the recurrence plugin is registered) |
 | `rawEvents` | `CalendarEvent[]` | The unexpanded source events as passed in. Use this to find a base recurring series by `uid` |
 | `resources` | `Resource[]` | Resources on the calendar. Empty array when none are set |
+| `orientation` | `'horizontal' \| 'vertical'` | The axis the views lay out along. Defaults to `'horizontal'`; relevant for resource calendars |
 | `isEventFormOpen` | `boolean` | Whether the event form modal is currently open |
 | `selectedEvent` | `CalendarEvent \| null` | The currently selected event, if any |
 | `selectedDate` | `Dayjs \| null` | The currently selected date, if any |

--- a/apps/website/src/content/docs/plugins/drag-to-create.mdx
+++ b/apps/website/src/content/docs/plugins/drag-to-create.mdx
@@ -1,0 +1,109 @@
+---
+title: Drag-to-Create Plugin
+description: Drag across empty cells to open the event form preselected with that time range.
+slug: docs/plugins/drag-to-create
+---
+
+The drag-to-create plugin lets users **press an empty cell and drag across the grid** to select a time range. Releasing opens the event form preselected with that range (or runs your own `onSelect`). It is an opt-in plugin, so you register it through the `plugins` prop.
+
+It works in the month, week, and day views, on both regular and resource calendars, in either orientation.
+
+## Installation
+
+Import `dragToCreatePlugin` from the `@ilamy/calendar/plugins/drag-to-create` subpath and pass it to `plugins`:
+
+```tsx
+import { IlamyCalendar } from '@ilamy/calendar';
+import { dragToCreatePlugin } from '@ilamy/calendar/plugins/drag-to-create';
+
+export default function MyCalendar() {
+  return (
+    <IlamyCalendar
+      events={events}
+      initialView="week"
+      plugins={[dragToCreatePlugin()]}
+    />
+  );
+}
+```
+
+With no options, a completed drag opens the event form with `start`, `end`, `allDay`, and `resourceId` prefilled from the selection.
+
+## How the gesture works
+
+- **Mouse / pen**: a drag starts once the pointer moves past a small threshold, so a plain click still falls through to `onCellClick`.
+- **Touch**: a drag starts on a short press-and-hold, then drag. A quick swipe still scrolls the page instead of selecting.
+- **Auto-scroll**: holding the pointer near an edge of the scroll area scrolls it so the selection can extend past what is currently visible. On a resource calendar the scroll is locked to the axis the resources lay out on, so a drag never scrolls across resources.
+- **Single region**: a selection never mixes all-day and timed cells and never spans resources. A cross-day timed drag becomes a multi-day timed range; month and all-day drags span days.
+- Pressing **Escape**, or the window losing focus, cancels an in-progress selection.
+
+## Options
+
+```ts
+dragToCreatePlugin(options?: DragToCreateOptions)
+
+interface DragToCreateOptions {
+  onSelect?: (
+    selection: CellInfo,
+    openEventForm: (input: OpenEventFormInput) => void
+  ) => void;
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `onSelect` | `(selection, openEventForm) => void` | — | Runs when a drag is committed. Omit to get the default (open the form preselected with the range). Provide to replace that default. |
+
+### `onSelect`
+
+`selection` is a [`CellInfo`](#cellinfo) spanning the dragged range, the same shape `onCellClick` receives. `openEventForm` is the calendar's own form opener, passed in so you can still open the form after running your own logic.
+
+```tsx
+<IlamyCalendar
+  events={events}
+  plugins={[
+    dragToCreatePlugin({
+      onSelect: (selection, openEventForm) => {
+        // Run your own logic, then open the form (or do something else entirely).
+        console.log('selected', selection.start.toISOString(), selection.end.toISOString());
+        openEventForm({
+          start: selection.start,
+          end: selection.end,
+          allDay: selection.allDay,
+          resource: selection.resource,
+        });
+      },
+    }),
+  ]}
+/>
+```
+
+#### CellInfo
+
+```ts
+interface CellInfo {
+  start: Dayjs;        // start of the selected range
+  end: Dayjs;          // end of the selected range
+  resource?: Resource; // the resource on a resource calendar; undefined otherwise
+  allDay?: boolean;    // true for an all-day / month selection
+}
+```
+
+## Combining with other plugins
+
+Plugins compose. Pass them all in the `plugins` array:
+
+```tsx
+import { recurrencePlugin } from '@ilamy/calendar/plugins/recurrence';
+import { dragToCreatePlugin } from '@ilamy/calendar/plugins/drag-to-create';
+
+<IlamyCalendar
+  events={events}
+  plugins={[recurrencePlugin(), dragToCreatePlugin()]}
+/>
+```
+
+## Notes
+
+- The plugin is bundled into `@ilamy/calendar` and exposed at the `@ilamy/calendar/plugins/drag-to-create` subpath. There is no separate package to install.
+- Selection reuses the public `CellInfo` and `openEventForm`, so it stays consistent with `onCellClick` and the rest of the calendar API.


### PR DESCRIPTION
Documents the public-facing changes that landed with the drag-to-create plugin (#214) and an earlier prop addition.

## What

- **New `plugins/drag-to-create.mdx` page** (+ sidebar entry): gesture model (mouse/pen threshold vs touch press-and-hold), edge auto-scroll, single-region clamp, the `onSelect` option and `CellInfo` shape, and composing with other plugins.
- **`calendar.mdx`**:
  - `getCellClassName` prop (added in `8a37e24`): table row next to `isCellDisabled`, a "Styling Cells" example, and an updated CellInfo reference.
  - `headerClassName` prop: previously undocumented, added to the Basic Props table.
- **`use-ilamy-calendar-context.mdx`**: `orientation` added to the `IlamyCalendarApi` return-values table.

## Verification

- Audited the full `IlamyCalendarProps` and public exports against the docs; `getCellClassName` and `headerClassName` were the only undocumented props.
- `bun run --filter '@ilamy/website' build` passes; all edited pages render and the new sidebar slug resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
