### PR TITLE
fix(calendar): make dayjs a peer dependency so locales reach the calendar

### DIFF
--- a/apps/website/src/content/docs/features/internationalization.mdx
+++ b/apps/website/src/content/docs/features/internationalization.mdx
@@ -14,6 +14,8 @@ The simplest way to internationalize your calendar is by setting the locale and 
 
 :::important
 For proper date formatting, you must explicitly import the corresponding `dayjs` locale in your application. The calendar component uses `dayjs` internally but does not bundle all locales to keep the bundle size small.
+
+`dayjs` is a [peer dependency](/docs/getting-started/installation#peer-dependencies), so the calendar shares your app's `dayjs` instance. Importing the locale once in your app registers it for the calendar too — no extra syncing of locale data between copies is needed.
 :::
 
 ```tsx title="Importing Locales"

--- a/apps/website/src/content/docs/getting-started/installation.mdx
+++ b/apps/website/src/content/docs/getting-started/installation.mdx
@@ -32,3 +32,38 @@ Get started with ilamy Calendar by installing it via your preferred package mana
     ```
   </TabItem>
 </Tabs>
+
+## Peer dependencies
+
+ilamy Calendar declares a few packages as **peer dependencies** so your app and the calendar share a single copy. This matters most for `dayjs`: the calendar's API uses `dayjs` objects (e.g. `CalendarEvent.start`), and date labels are localized through your app's `dayjs` instance. A shared copy means the `dayjs` locale you import in your app also applies to the calendar (no extra wiring).
+
+- `dayjs` (`^1.11.20`)
+- `react` and `react-dom` (`^19`)
+- `tailwindcss` (`^4`) and `tailwindcss-animate`
+
+Install `dayjs` alongside the calendar (your React and Tailwind setup already provides the rest):
+
+<Tabs>
+  <TabItem label="npm">
+    ```bash
+    npm install @ilamy/calendar dayjs
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm add @ilamy/calendar dayjs
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn add @ilamy/calendar dayjs
+    ```
+  </TabItem>
+  <TabItem label="bun">
+    ```bash
+    bun add @ilamy/calendar dayjs
+    ```
+  </TabItem>
+</Tabs>
+
+To localize date labels, set the `locale` prop and import the matching `dayjs` locale once in your app. See [Internationalization](/docs/features/internationalization).

--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,6 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "dayjs": "^1.11.20",
         "lucide-react": "^0.475.0",
         "motion": "^12.36.0",
         "rrule": "^2.8.1",
@@ -126,8 +125,10 @@
         "@ilamy/types": "workspace:*",
         "@ilamy/ui": "workspace:*",
         "@ilamy/utils": "workspace:*",
+        "dayjs": "^1.11.20",
       },
       "peerDependencies": {
+        "dayjs": "^1.11.20",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwindcss": "^4.2.2",

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -200,6 +200,27 @@ Everything that was previously accessible via deep imports is either available f
 
 ---
 
+## 7. `dayjs` is now a peer dependency
+
+`dayjs` moved from a bundled dependency to a **peer dependency** so your app and the calendar share a single `dayjs` instance. Previously, package managers (notably pnpm) could resolve a separate `dayjs` copy for `@ilamy/calendar`, so a locale you imported in your app (`import 'dayjs/locale/fr'`) registered onto your copy but not the calendar's, leaving some dates unlocalized.
+
+Install `dayjs` explicitly (most apps already do, since `CalendarEvent.start`/`end` are `dayjs` objects):
+
+```bash
+npm install dayjs
+```
+
+With a shared instance, localizing dates is just importing the locale once in your app — no copying locale data between instances:
+
+```ts
+import 'dayjs/locale/fr'
+// <IlamyCalendar locale="fr" />
+```
+
+If you previously worked around the split instance (e.g. reading `rootDayjs.Ls[locale]` and calling `dayjs.locale(data, undefined, true)` on the calendar's `dayjs`), you can delete that code.
+
+---
+
 ## Type tightening (v2 structure overhaul, Phase 0)
 
 ### `Translations` is now a derived type alias, not an interface
@@ -402,6 +423,7 @@ Other notes:
 - [ ] Replace `updateRecurringEvent` calls with `applyScopedEdit` and `deleteRecurringEvent` calls with `applyScopedDelete`.
 - [ ] Remove any calls to `findParentRecurringEvent`; use `rawEvents` filtering instead if needed.
 - [ ] Remove any deep `@ilamy/calendar/src/...` imports; use only the two public entry points.
+- [ ] Install `dayjs` as a direct dependency (it is now a peer dependency). Remove any workaround that synced locale data between a separate app `dayjs` copy and the calendar's.
 - [ ] If you have TypeScript code that narrows `CalendarView` as an exhaustive union, update it for the new `string` type.
 - [ ] If you read properties off `event.data` / `resource.data`, add narrowing or a boundary cast (`Record<string, unknown>` now).
 - [ ] Remove any use of `Resource.position`; order the `resources` array instead.

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -71,6 +71,7 @@
 		"postpack": "bun scripts/postpack.ts"
 	},
 	"peerDependencies": {
+		"dayjs": "^1.11.20",
 		"react": "^19.2.0",
 		"react-dom": "^19.2.0",
 		"tailwindcss": "^4.2.2",
@@ -89,7 +90,6 @@
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
-		"dayjs": "^1.11.20",
 		"lucide-react": "^0.475.0",
 		"motion": "^12.36.0",
 		"rrule": "^2.8.1",
@@ -101,7 +101,8 @@
 		"@ilamy/calendar-recurrence": "workspace:*",
 		"@ilamy/types": "workspace:*",
 		"@ilamy/ui": "workspace:*",
-		"@ilamy/utils": "workspace:*"
+		"@ilamy/utils": "workspace:*",
+		"dayjs": "^1.11.20"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Closes #217.

## Problem

`dayjs` was a regular **dependency** of `@ilamy/calendar`. Under strict package managers (pnpm), that means `@ilamy/calendar` resolves its *own* nested `dayjs` copy — a separate module instance with its own locale registry (`Ls`). A consumer's documented `import 'dayjs/locale/fr'` registers the locale onto the app's `dayjs`, but never the calendar's copy, so the calendar's date labels stay English. Reporters worked around it by copying locale data between the two instances.

## Fix

Move `dayjs` from `dependencies` to `peerDependencies` (+ `devDependencies` for local build/test). With a shared instance, the locale a consumer imports reaches the calendar — no workaround needed.

- The build already **externalizes** `dayjs` (bunup externalizes deps/peerDeps; verified `dist` keeps bare `from"dayjs"` imports and does not inline the library), so the published artifact is unchanged in size.
- The calendar's API already requires consumers to use `dayjs` (e.g. `CalendarEvent.start` is a `Dayjs`), so a peer dependency formalizes what every consumer already installs.

## Docs

- Installation: a **Peer dependencies** section, with `dayjs` called out and install commands including it.
- Internationalization: clarified that `dayjs` is a shared peer, so importing the locale once in your app applies to the calendar (no syncing of locale data between copies).
- `migration-v2.md`: entry #7 documenting the dep → peer change and that the old sync workaround can be removed.

## Verification

- Built `@ilamy/calendar` localizes correctly when `dayjs` is shared (consumer `import 'dayjs/locale/fr'` -> calendar renders `janvier`), confirmed against the built `dist`.
- Reproduced the bug deterministically (separate nested `dayjs` copy -> calendar stays English) and the fix (shared instance -> localized).
- Full suite green; website builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
