### PR TITLE
feat(event-form): add a color picker with custom colors

### DIFF
--- a/docs/logs/2026-06-24.md
+++ b/docs/logs/2026-06-24.md
@@ -2,6 +2,22 @@
 
 ## Changes
 
+- **[ui/event-form]**: Added a `ColorPicker` (new `@ilamy/ui` primitive) to the
+  event form: a Popover with the original 14 Tailwind class-pair swatches
+  (theme-aware, rendered via their own className) PLUS a native
+  `<input type="color">` + hex field for any custom color (no new dependency,
+  built on Popover + Input). The stored value stays a class-pair when a swatch is
+  picked (backward compatible); a custom pick stores `backgroundColor` (hex) +
+  a `readableTextColor()`-derived `color`. Existing events are never rewritten
+  unless the user actually picks a new color — editing other fields preserves the
+  original color (legacy class-pair or hex) exactly.
+- **[utils]**: Added `readableTextColor(hex)` to `@ilamy/utils/helpers`
+  (YIQ perceived-brightness, W3C AERT formula) — picks black/white for contrast
+  on custom hex colors.
+- **[event-form]**: The Description field now renders a multi-line `Textarea`
+  (via a `multiline` option on the shared `EventFormTextField`) instead of a
+  single-line `Input` (also avoids the input autofill dropdown).
+
 - **[calendar/header]**: Replaced the month/year/week/day title dropdowns in the
   header with `Select` instead of a `Popover` + list of `Button`s. Each picker is
   now a controlled `Select` whose options carry the `Dayjs` they navigate to;
@@ -32,6 +48,14 @@
 
 ## Files Modified
 
+- `packages/ui/src/components/color-picker.tsx` - new `ColorPicker` primitive.
+- `packages/utils/src/helpers.ts` - added `readableTextColor(hex)`.
+- `packages/calendar/src/features/calendar/components/event-form/event-form.tsx` -
+  swapped the swatch buttons for `ColorPicker`; stores `backgroundColor` + derived
+  `color`; legacy class-pair color constants removed.
+- `packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx` -
+  Color Selection tests rewritten for the picker (open trigger -> swatch ->
+  assert `backgroundColor`/`color` on save).
 - `packages/calendar/src/features/calendar/components/header/title-content.tsx` -
   rewritten from Popover+Button to Select; options are plain data (string label +
   `today` flag), the "today" badge is rendered at the `SelectItem` level.

--- a/packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx
+++ b/packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx
@@ -216,30 +216,95 @@ describe('EventForm', () => {
 	})
 
 	describe('Color Selection', () => {
-		it('should render color options', () => {
+		it('should render the Tailwind class-pair swatches in the picker', () => {
 			renderEventForm({ ...defaultProps, selectedEvent: testNewEvent })
 
-			// Check that multiple color options are rendered
-			const colorButtons = screen
-				.getAllByRole('button')
-				.filter(
-					(button) =>
-						button.getAttribute('aria-label')?.includes('Blue') ||
-						button.getAttribute('aria-label')?.includes('Red') ||
-						button.getAttribute('aria-label')?.includes('Green')
-				)
+			fireEvent.click(screen.getByRole('button', { name: 'Color' }))
 
-			expect(colorButtons.length).toBeGreaterThan(0)
+			expect(screen.getByLabelText('Red')).toBeInTheDocument()
+			expect(screen.getByLabelText('Green')).toBeInTheDocument()
 		})
 
-		it('should select a color when clicked', () => {
+		it('should seed the picker from a legacy class-pair color', () => {
+			const legacyEvent: CalendarEvent = {
+				...testEvent,
+				backgroundColor: undefined,
+				color: 'bg-red-100 text-red-800',
+			}
+			renderEventForm({ ...defaultProps, selectedEvent: legacyEvent })
+
+			fireEvent.click(screen.getByRole('button', { name: 'Color' }))
+
+			expect(screen.getByLabelText('Red')).toHaveAttribute(
+				'aria-pressed',
+				'true'
+			)
+		})
+
+		it('should preserve a legacy class-pair color when the color is not changed', async () => {
+			const legacyEvent: CalendarEvent = {
+				...testEvent,
+				backgroundColor: undefined,
+				color: 'bg-red-100 text-red-800',
+			}
+			renderEventForm({ ...defaultProps, selectedEvent: legacyEvent })
+
+			fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+			await waitFor(() => {
+				expect(mockOnUpdate).toHaveBeenCalledWith(
+					expect.objectContaining({
+						color: 'bg-red-100 text-red-800',
+						backgroundColor: undefined,
+					})
+				)
+			})
+		})
+
+		it('should store the picked swatch class-pair color on save', async () => {
 			renderEventForm({ ...defaultProps, selectedEvent: testNewEvent })
 
-			const redColorButton = screen.getByLabelText('Red')
-			fireEvent.click(redColorButton)
+			fireEvent.change(screen.getByPlaceholderText('Event title'), {
+				target: { value: 'Swatch Event' },
+			})
 
-			// The button should have ring classes indicating selection
-			expect(redColorButton).toHaveClass('ring-2', 'ring-black')
+			fireEvent.click(screen.getByRole('button', { name: 'Color' }))
+			fireEvent.click(screen.getByLabelText('Red'))
+
+			fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+			await waitFor(() => {
+				expect(mockOnAdd).toHaveBeenCalledWith(
+					expect.objectContaining({
+						color: 'bg-red-100 text-red-800',
+						backgroundColor: undefined,
+					})
+				)
+			})
+		})
+
+		it('should store a custom hex background and readable text color on save', async () => {
+			renderEventForm({ ...defaultProps, selectedEvent: testNewEvent })
+
+			fireEvent.change(screen.getByPlaceholderText('Event title'), {
+				target: { value: 'Custom Event' },
+			})
+
+			fireEvent.click(screen.getByRole('button', { name: 'Color' }))
+			fireEvent.change(screen.getByLabelText('Hex color'), {
+				target: { value: '#ef4444' },
+			})
+
+			fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+			await waitFor(() => {
+				expect(mockOnAdd).toHaveBeenCalledWith(
+					expect.objectContaining({
+						backgroundColor: '#ef4444',
+						color: '#ffffff',
+					})
+				)
+			})
 		})
 	})
 

--- a/packages/calendar/src/features/calendar/components/event-form/event-form.tsx
+++ b/packages/calendar/src/features/calendar/components/event-form/event-form.tsx
@@ -1,6 +1,7 @@
 import type { CalendarEvent } from '@ilamy/types'
 import { Button } from '@ilamy/ui/components/button'
 import { Checkbox } from '@ilamy/ui/components/checkbox'
+import { ColorPicker } from '@ilamy/ui/components/color-picker'
 import { DialogFooter } from '@ilamy/ui/components/dialog'
 import { Input } from '@ilamy/ui/components/input'
 import { Label } from '@ilamy/ui/components/label'
@@ -12,8 +13,9 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@ilamy/ui/components/select'
-import { cn } from '@ilamy/ui/lib/utils'
+import { Textarea } from '@ilamy/ui/components/textarea'
 import dayjs from '@ilamy/utils/dayjs'
+import { readableTextColor } from '@ilamy/utils/helpers'
 import type React from 'react'
 import { useEffect, useState } from 'react'
 import {
@@ -32,9 +34,12 @@ import {
 } from '@/features/calendar/utils/event-form-utils'
 import { useScopedEventMutation } from '@/hooks/use-scoped-event-mutation'
 
+// Default event color, kept as a Tailwind class-pair (theme-aware) like before.
 const DEFAULT_EVENT_COLOR = 'bg-blue-100 text-blue-800'
 
-const COLOR_OPTIONS = [
+// Curated swatches: the original Tailwind class-pairs (theme-aware). The picker
+// additionally allows any custom color via its native input + hex field.
+const EVENT_COLOR_SWATCHES = [
 	{ value: DEFAULT_EVENT_COLOR, label: 'Blue' },
 	{ value: 'bg-green-100 text-green-800', label: 'Green' },
 	{ value: 'bg-purple-100 text-purple-800', label: 'Purple' },
@@ -51,6 +56,53 @@ const COLOR_OPTIONS = [
 	{ value: 'bg-orange-100 text-orange-800', label: 'Orange' },
 ]
 
+const HEX_COLOR_PATTERN = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+// The picker's value is whatever the event already stored (a Tailwind class-pair
+// from a swatch, or a hex). Prefer a hex `backgroundColor`, then `color`, else
+// the default class-pair.
+const resolveInitialColor = (
+	backgroundColor: string | undefined,
+	color: string | undefined
+): string => {
+	if (backgroundColor && HEX_COLOR_PATTERN.test(backgroundColor)) {
+		return backgroundColor
+	}
+	return color ?? DEFAULT_EVENT_COLOR
+}
+
+// A swatch stores a Tailwind class-pair in `color`; a custom hex stores
+// `backgroundColor` + a readable text `color`.
+const buildColorFields = (
+	color: string
+): Pick<CalendarEvent, 'backgroundColor' | 'color'> => {
+	if (HEX_COLOR_PATTERN.test(color)) {
+		return { backgroundColor: color, color: readableTextColor(color) }
+	}
+	return { backgroundColor: undefined, color }
+}
+
+// Write the new color only when the user picked one (or the event had none).
+// Otherwise preserve the event's original color (legacy class-pair or hex) as-is.
+const resolveColorFields = ({
+	colorChanged,
+	hadInitialColor,
+	selectedColor,
+	initialBackgroundColor,
+	initialColor,
+}: {
+	colorChanged: boolean
+	hadInitialColor: boolean
+	selectedColor: string
+	initialBackgroundColor: string | undefined
+	initialColor: string | undefined
+}): Pick<CalendarEvent, 'backgroundColor' | 'color'> => {
+	if (colorChanged || !hadInitialColor) {
+		return buildColorFields(selectedColor)
+	}
+	return { backgroundColor: initialBackgroundColor, color: initialColor }
+}
+
 type TextFieldName = 'title' | 'description' | 'location'
 
 interface EventFormTextFieldProps {
@@ -59,6 +111,8 @@ interface EventFormTextFieldProps {
 	placeholder: string
 	value: string
 	required?: boolean
+	// Render a multi-line textarea (e.g. for the description) instead of an input.
+	multiline?: boolean
 	onChange: (
 		e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
 	) => void
@@ -71,21 +125,34 @@ const EventFormTextField = ({
 	placeholder,
 	value,
 	required = false,
+	multiline = false,
 	onChange,
 }: EventFormTextFieldProps) => (
 	<div className="grid gap-1 sm:gap-2">
 		<Label className="text-xs sm:text-sm" htmlFor={name}>
 			{label}
 		</Label>
-		<Input
-			className="h-8 text-sm sm:h-9"
-			id={name}
-			name={name}
-			onChange={onChange}
-			placeholder={placeholder}
-			required={required}
-			value={value}
-		/>
+		{multiline ? (
+			<Textarea
+				className="min-h-16 text-sm"
+				id={name}
+				name={name}
+				onChange={onChange}
+				placeholder={placeholder}
+				required={required}
+				value={value}
+			/>
+		) : (
+			<Input
+				className="h-8 text-sm sm:h-9"
+				id={name}
+				name={name}
+				onChange={onChange}
+				placeholder={placeholder}
+				required={required}
+				value={value}
+			/>
+		)}
 	</div>
 )
 
@@ -129,7 +196,8 @@ export const EventForm: React.FC<EventFormProps> = ({
 		start = dayjs(),
 		end = dayjs().add(1, 'hour'),
 		allDay: initialAllDay = false,
-		color: initialColor = DEFAULT_EVENT_COLOR,
+		color: initialColor,
+		backgroundColor: initialBackgroundColor,
 		title: initialTitle = '',
 		description: initialDescription = '',
 		location: initialLocation = '',
@@ -155,7 +223,18 @@ export const EventForm: React.FC<EventFormProps> = ({
 	const [startDate, setStartDate] = useState(start.toDate())
 	const [endDate, setEndDate] = useState(end.toDate())
 	const [isAllDay, setIsAllDay] = useState(initialAllDay)
-	const [selectedColor, setSelectedColor] = useState(initialColor)
+	const [selectedColor, setSelectedColor] = useState(
+		resolveInitialColor(initialBackgroundColor, initialColor)
+	)
+	// Existing events keep their original color (including legacy Tailwind
+	// class-pairs) untouched unless the user actually picks a new one.
+	const [colorPicked, setColorPicked] = useState(false)
+	const hadInitialColor = Boolean(initialColor || initialBackgroundColor)
+
+	const handleColorChange = (color: string) => {
+		setSelectedColor(color)
+		setColorPicked(true)
+	}
 
 	// Time state
 	const [startTime, setStartTime] = useState(start.format('HH:mm'))
@@ -245,6 +324,17 @@ export const EventForm: React.FC<EventFormProps> = ({
 		const startDateTime = buildDateTime(startDate, startTime, isAllDay)
 		const endDateTime = buildEndDateTime(endDate, endTime, isAllDay)
 
+		// Only write the new hex model when the user picked a color. Otherwise an
+		// existing event keeps its original color (legacy class-pair included) so
+		// editing other fields never rewrites its appearance.
+		const colorFields = resolveColorFields({
+			colorChanged: colorPicked,
+			hadInitialColor,
+			selectedColor,
+			initialBackgroundColor,
+			initialColor,
+		})
+
 		const eventData: CalendarEvent = {
 			id: selectedEventId || dayjs().format('YYYYMMDDHHmmss'),
 			title: formValues.title,
@@ -254,7 +344,7 @@ export const EventForm: React.FC<EventFormProps> = ({
 			description: formValues.description,
 			location: formValues.location,
 			allDay: isAllDay,
-			color: selectedColor,
+			...colorFields,
 			...pluginUpdates,
 		}
 
@@ -337,6 +427,7 @@ export const EventForm: React.FC<EventFormProps> = ({
 						/>
 						<EventFormTextField
 							label={t('description')}
+							multiline
 							name="description"
 							onChange={handleInputChange}
 							placeholder={t('eventDescriptionPlaceholder')}
@@ -423,22 +514,12 @@ export const EventForm: React.FC<EventFormProps> = ({
 
 						<div className="grid gap-1 sm:gap-2">
 							<Label className="text-xs sm:text-sm">{t('color')}</Label>
-							<div className="flex flex-wrap gap-2">
-								{COLOR_OPTIONS.map((color) => (
-									<Button
-										aria-label={color.label}
-										className={cn(
-											`${color.value} h-6 w-6 rounded-full sm:h-8 sm:w-8`,
-											selectedColor === color.value &&
-												'ring-2 ring-black ring-offset-1 sm:ring-offset-2'
-										)}
-										key={color.value}
-										onClick={() => setSelectedColor(color.value)}
-										type="button"
-										variant="ghost"
-									/>
-								))}
-							</div>
+							<ColorPicker
+								aria-label={t('color')}
+								onChange={handleColorChange}
+								swatches={EVENT_COLOR_SWATCHES}
+								value={selectedColor}
+							/>
 						</div>
 
 						<EventFormTextField

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -6,7 +6,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
 	return (
 		<div
 			className={cn(
-				'text-card-foreground flex flex-col gap-6 rounded-xl border shadow-sm',
+				'text-card-foreground flex flex-col gap-1 rounded-xl border shadow-sm',
 				className
 			)}
 			data-slot="card"
@@ -48,19 +48,6 @@ function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
 	)
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
-	return (
-		<div
-			className={cn(
-				'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
-				className
-			)}
-			data-slot="card-action"
-			{...props}
-		/>
-	)
-}
-
 function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
 	return (
 		<div
@@ -71,22 +58,4 @@ function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
 	)
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
-	return (
-		<div
-			className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
-			data-slot="card-footer"
-			{...props}
-		/>
-	)
-}
-
-export {
-	Card,
-	CardAction,
-	CardContent,
-	CardDescription,
-	CardFooter,
-	CardHeader,
-	CardTitle,
-}
+export { Card, CardContent, CardDescription, CardHeader, CardTitle }

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -1,0 +1,124 @@
+import { ChevronDownIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+import { cn } from '../lib/utils'
+import { Input } from './input'
+import { Popover, PopoverContent, PopoverTrigger } from './popover'
+
+const HEX_PATTERN = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+const isHex = (value: string | undefined): value is string =>
+	Boolean(value && HEX_PATTERN.test(value))
+
+interface ColorSwatch {
+	/** The value stored when picked: a Tailwind class string (e.g. `bg-blue-100 text-blue-800`) or a hex. */
+	value: string
+	label: string
+}
+
+interface ColorPickerProps {
+	/** Current color: a Tailwind class string (from a swatch) or a hex string (from the custom input). */
+	value?: string
+	onChange: (value: string) => void
+	/** Preset swatches rendered with their own className (so Tailwind classes stay theme-aware). */
+	swatches?: ColorSwatch[]
+	className?: string
+	'aria-label'?: string
+}
+
+function ColorPicker({
+	value,
+	onChange,
+	swatches = [],
+	className,
+	'aria-label': ariaLabel = 'Select color',
+}: ColorPickerProps) {
+	// The hex field is editable while the user types an incomplete value, so it
+	// keeps its own state and only propagates once the value is a valid hex.
+	const [hexText, setHexText] = useState(isHex(value) ? value : '')
+	useEffect(() => {
+		setHexText(isHex(value) ? value : '')
+	}, [value])
+
+	const handleHexChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const next = event.target.value
+		setHexText(next)
+		if (HEX_PATTERN.test(next)) {
+			onChange(next)
+		}
+	}
+
+	const valueIsHex = isHex(value)
+	const selectedSwatch = swatches.find((swatch) => swatch.value === value)
+	const triggerLabel =
+		selectedSwatch?.label ?? (valueIsHex ? value : 'Pick a color')
+
+	return (
+		<Popover>
+			<PopoverTrigger
+				aria-label={ariaLabel}
+				className={cn(
+					'border-input focus-visible:border-ring focus-visible:ring-ring/50 flex h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-md border bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:ring-[3px]',
+					className
+				)}
+				data-slot="color-picker-trigger"
+				type="button"
+			>
+				<span className="flex items-center gap-2">
+					<span
+						className={cn(
+							'size-5 shrink-0 rounded-full border',
+							!valueIsHex && value
+						)}
+						style={valueIsHex ? { backgroundColor: value } : undefined}
+					/>
+					<span className={cn(valueIsHex && 'font-mono text-xs')}>
+						{triggerLabel}
+					</span>
+				</span>
+				<ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+			</PopoverTrigger>
+			<PopoverContent className="w-56" data-slot="color-picker-content">
+				{swatches.length > 0 && (
+					<div className="grid grid-cols-7 gap-1.5">
+						{swatches.map((swatch) => {
+							const isSelected = value === swatch.value
+							return (
+								<button
+									aria-label={swatch.label}
+									aria-pressed={isSelected}
+									className={cn(
+										'focus-visible:ring-ring size-6 cursor-pointer rounded-full border outline-none focus-visible:ring-2',
+										swatch.value,
+										isSelected && 'ring-ring ring-2 ring-offset-1'
+									)}
+									key={swatch.value}
+									onClick={() => onChange(swatch.value)}
+									type="button"
+								/>
+							)
+						})}
+					</div>
+				)}
+				<div className="text-muted-foreground mt-3 mb-1.5 text-xs">Custom</div>
+				<div className="flex items-center gap-2">
+					<input
+						aria-label="Custom color"
+						className="size-9 shrink-0 cursor-pointer rounded-md border bg-transparent"
+						onChange={(event) => onChange(event.target.value)}
+						type="color"
+						value={valueIsHex ? value : '#000000'}
+					/>
+					<Input
+						aria-label="Hex color"
+						className="font-mono"
+						onChange={handleHexChange}
+						placeholder="#000000"
+						value={hexText}
+					/>
+				</div>
+			</PopoverContent>
+		</Popover>
+	)
+}
+
+export { ColorPicker }

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -23,3 +23,29 @@ export function safeDate(
  */
 export const listKey = (...parts: Array<string | number>): string =>
 	parts.join('-')
+
+/**
+ * Picks black or white as the most readable text color over a solid hex
+ * background. Uses the standard YIQ perceived-brightness formula
+ * (https://www.w3.org/TR/AERT/#color-contrast): brightness >= 128 is a light
+ * background and gets dark text, otherwise white. Accepts `#rgb` or `#rrggbb`;
+ * an unparseable value falls back to dark text.
+ */
+export function readableTextColor(hex: string): '#000000' | '#ffffff' {
+	const normalized = hex.replace('#', '')
+	const expanded =
+		normalized.length === 3
+			? normalized
+					.split('')
+					.map((channel) => channel + channel)
+					.join('')
+			: normalized
+	if (!/^[0-9a-fA-F]{6}$/.test(expanded)) {
+		return '#000000'
+	}
+	const red = Number.parseInt(expanded.slice(0, 2), 16)
+	const green = Number.parseInt(expanded.slice(2, 4), 16)
+	const blue = Number.parseInt(expanded.slice(4, 6), 16)
+	const brightness = (red * 299 + green * 587 + blue * 114) / 1000
+	return brightness >= 128 ? '#000000' : '#ffffff'
+}


### PR DESCRIPTION
## What

Adds a proper color picker to the event form so events can use any color, not just the fixed presets.

- **New `ColorPicker` primitive** (`@ilamy/ui`, built on Popover + Input, no new dependency): trigger shows a color dot + label + chevron; the popup has the original Tailwind class-pair swatches plus a native `<input type="color">` + a hex field for custom colors.
- **Swatches stay Tailwind class-pairs** (theme-aware) and store a class-pair in `event.color` exactly like before. A **custom pick** stores `event.backgroundColor` (hex) + a `readableTextColor()`-derived `event.color`.
- **`readableTextColor(hex)`** added to `@ilamy/utils/helpers` (YIQ perceived-brightness, [W3C AERT](https://www.w3.org/TR/AERT/#color-contrast)) — black/white for contrast.
- **Backward compatible:** an existing event's color (legacy class-pair or hex) is preserved untouched unless the user actually picks a new color. Editing other fields never rewrites the appearance.
- **Description** field is now a multi-line `Textarea` instead of a single-line input.

## Also in this PR
- `Card`: `gap-6` -> `gap-1`, and removed the unused `CardAction`/`CardFooter` exports (no consumers).

## Tests
- 814 calendar tests pass. New/updated event-form cases: swatch pick saves the class-pair; custom hex saves `backgroundColor` + contrast `color`; a legacy class-pair event seeds the matching swatch and is preserved when untouched.
- type-check clean, biome clean, fallow new-only gate clean.