### PR TITLE
fix(event-form): label color trigger from Tailwind class, not 'Pick a color'

### DIFF
--- a/docs/logs/2026-06-24.md
+++ b/docs/logs/2026-06-24.md
@@ -17,6 +17,9 @@
 - **[event-form]**: The Description field now renders a multi-line `Textarea`
   (via a `multiline` option on the shared `EventFormTextField`) instead of a
   single-line `Input` (also avoids the input autofill dropdown).
+- **[ui]**: `ColorPicker` trigger derives a label from a Tailwind background
+  class (`bg-cyan-100 ...` -> "Cyan") so colors outside the swatch set show their
+  name instead of "Pick a color" (which now only shows when no color is set).
 
 - **[calendar/header]**: Replaced the month/year/week/day title dropdowns in the
   header with `Select` instead of a `Popover` + list of `Button`s. Each picker is

--- a/packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx
+++ b/packages/calendar/src/features/calendar/components/event-form/event-form.test.tsx
@@ -241,6 +241,19 @@ describe('EventForm', () => {
 			)
 		})
 
+		it('should label the trigger from a Tailwind color not in the swatches', () => {
+			const cyanEvent: CalendarEvent = {
+				...testEvent,
+				backgroundColor: undefined,
+				color: 'bg-cyan-100 text-cyan-800',
+			}
+			renderEventForm({ ...defaultProps, selectedEvent: cyanEvent })
+
+			expect(screen.getByRole('button', { name: 'Color' })).toHaveTextContent(
+				'Cyan'
+			)
+		})
+
 		it('should preserve a legacy class-pair color when the color is not changed', async () => {
 			const legacyEvent: CalendarEvent = {
 				...testEvent,

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -9,6 +9,16 @@ const HEX_PATTERN = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
 const isHex = (value: string | undefined): value is string =>
 	Boolean(value && HEX_PATTERN.test(value))
 
+// Derive a readable name from a Tailwind background class (e.g.
+// `bg-cyan-100 text-cyan-800` -> `Cyan`), falling back to `Custom`.
+const colorNameFromClass = (value: string): string => {
+	const name = value.match(/bg-([a-z]+)-\d+/)?.at(1)
+	if (!name) {
+		return 'Custom'
+	}
+	return name.charAt(0).toUpperCase() + name.slice(1)
+}
+
 interface ColorSwatch {
 	/** The value stored when picked: a Tailwind class string (e.g. `bg-blue-100 text-blue-800`) or a hex. */
 	value: string
@@ -49,8 +59,17 @@ function ColorPicker({
 
 	const valueIsHex = isHex(value)
 	const selectedSwatch = swatches.find((swatch) => swatch.value === value)
-	const triggerLabel =
-		selectedSwatch?.label ?? (valueIsHex ? value : 'Pick a color')
+
+	let triggerLabel: string
+	if (selectedSwatch) {
+		triggerLabel = selectedSwatch.label
+	} else if (valueIsHex) {
+		triggerLabel = value
+	} else if (value) {
+		triggerLabel = colorNameFromClass(value)
+	} else {
+		triggerLabel = 'Pick a color'
+	}
 
 	return (
 		<Popover>


### PR DESCRIPTION
Follow-up to #221 (which merged before this fix was pushed).

A color outside the swatch set (e.g. the `bg-cyan-100 text-cyan-800` seed event "Daily Standup") fell through to the **"Pick a color"** trigger label while still rendering its color dot. The label now derives a name from the Tailwind background class (`bg-cyan-100 …` → **"Cyan"**); "Pick a color" shows only when no color is set. Swatch picks → swatch label, custom hex → the hex.

Verified: 815 calendar tests pass, type-check clean, biome clean, fallow gate clean.