### PR TITLE
docs(readme): add a Ko-fi support button

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ For comprehensive guides, API references, and interactive demos, visit [ilamy.de
 
 ---
 
+## Support
+
+ilamy Calendar is free and open source. If you'd like to support its development:
+
+<a href="https://ko-fi.com/kcsujeet" target="_blank"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Buy me a coffee at ko-fi.com" height="50" /></a>
+
+---
+
 ## License
 
 MIT © [Sujeet Kc](https://github.com/kcsujeet)


### PR DESCRIPTION
Adds a **Support** section near the end of the README (after Documentation, before License) with the Ko-fi button, linking to `ko-fi.com/kcsujeet` (matches the existing `FUNDING.yml` handle).

Root `README.md` is the single source of truth; `prepack.ts` copies it into the published package, so the button appears on both the GitHub homepage and the npm page.