### PR TITLE
fix(calendar): resource vertical-grid columns fill and align with header

### DIFF
--- a/docs/logs/2026-06-28.md
+++ b/docs/logs/2026-06-28.md
@@ -1,0 +1,43 @@
+# Development Log - 2026-06-28
+
+## Changes
+
+- **[vertical-grid]**: Fixed a long-standing resource vertical-grid alignment bug where the
+  header columns filled the viewport but the body columns shrank to their `min-w-20` floor
+  (left-aligned, empty space on the right), so header and body columns did not line up. The
+  fix adds `*:w-max` to the ScrollArea viewport's child classes.
+
+## Files Modified
+
+- `packages/calendar/src/components/vertical-grid/vertical-grid.tsx` - Added `*:w-max` to
+  `viewPortProps.className` (now `*:flex! *:flex-col! *:min-h-full *:w-max`) with an
+  explanatory comment.
+
+## Notes
+
+Root cause (the non-obvious part):
+
+- Radix `ScrollArea` wraps the viewport's content in an injected
+  `<div style="min-width:100%; display:table">`. Our `viewPortProps` already reshape it with
+  `*:flex! *:flex-col! *:min-h-full`, but its **width stays effectively indefinite**.
+- The vertical-grid **body** is `flex flex-1 min-w-full w-fit`. A non-sticky child sizing with
+  a percentage (`min-w-full`) against an indefinite-width parent resolves to 0, so `w-fit`
+  shrink-wraps the body to the sum of its columns' `min-w-20` minimums. The columns therefore
+  sit at the `min-w-20` floor instead of growing via `flex-1`.
+- The **header** (`VerticalGridHeaderContainer`) escapes this only because it is
+  `position: sticky` — a sticky box resolves its size against the scroll viewport (definite),
+  so its `min-w-full` resolves and its `flex-1` columns grow to fill. This is why the header
+  looked "longer" than the body even though both use `min-w-20`: `min-w-20` is just a floor;
+  `flex-1` grows past it only when the container is definite.
+- `*:w-max` makes the wrapper definite (`width: max-content`, i.e. grow to content) while the
+  injected `min-width:100%` keeps it at least the viewport width. With a definite-width
+  parent, the body's `min-w-full` resolves: columns fill when narrow, and the wrapper still
+  grows + scrolls when there are more columns than fit.
+
+Debugging takeaway: when a flex/percentage child unexpectedly shrink-wraps inside a Radix
+ScrollArea, suspect the `display:table` viewport wrapper being width-indefinite. Sticky
+children mask the problem; non-sticky ones expose it. Compare computed widths in DevTools
+(the wrapper measured ~524px while the sticky header filled).
+
+This is a `main` bug fix on branch `fix/resource-vertical-grid-alignment`; the Approach G
+(grid border frame) work will rebase on top of it.

--- a/packages/calendar/src/components/vertical-grid/vertical-grid.tsx
+++ b/packages/calendar/src/components/vertical-grid/vertical-grid.tsx
@@ -92,7 +92,16 @@ export const VerticalGrid: React.FC<VerticalGridProps> = ({
 				className={cn('h-full', isRegularCalendar && 'overflow-auto')}
 				data-testid="vertical-grid-scroll"
 				viewPortProps={{
-					className: '*:flex! *:flex-col! *:min-h-full',
+					// Radix ScrollArea wraps content in a `min-width:100%; display:table`
+					// div. `*:flex!/*:flex-col!/*:min-h-full` reshape it, but its width
+					// stays effectively indefinite, so a non-sticky child sizing with a
+					// percentage (the body's `min-w-full`) resolves to 0 and `w-fit`
+					// shrink-wraps it, leaving the body's columns at their `min-w-20`
+					// floor while the sticky header, which resolves against the scroll
+					// viewport, fills. `*:w-max` makes that wrapper definite (grow to
+					// content) while its `min-width:100%` keeps it >= the viewport, so the
+					// body fills when narrow and still scrolls when wide.
+					className: '*:flex! *:flex-col! *:min-h-full *:w-max',
 					ref: viewportRef,
 				}}
 			>


### PR DESCRIPTION
## Problem

In resource **vertical** views (month/week vertical), the header columns filled the viewport while the body columns shrank to their \`min-w-20\` floor (left-aligned, empty space on the right), so the header and body columns did not line up. This was a pre-existing bug on \`main\`.

## Root cause

Radix \`ScrollArea\` wraps the viewport content in an injected \`<div style="min-width:100%; display:table">\`. Our \`viewPortProps\` reshape it (\`*:flex! *:flex-col! *:min-h-full\`), but its width stays effectively **indefinite**.

- The body is \`flex flex-1 min-w-full w-fit\`. A non-sticky child sizing with a percentage (\`min-w-full\`) against an indefinite-width parent resolves to 0, so \`w-fit\` shrink-wraps it to the sum of its columns' \`min-w-20\` minimums — the columns never grow via \`flex-1\`.
- The header (\`VerticalGridHeaderContainer\`) escapes this only because it is \`position: sticky\` — a sticky box resolves against the scroll viewport (definite), so it fills. That asymmetry is why the header looked "longer" than the body despite both using \`min-w-20\`.

## Fix

One class on the ScrollArea viewport wrapper:

\`\`\`
viewPortProps.className: '*:flex! *:flex-col! *:min-h-full'  ->  '... *:w-max'
\`\`\`

\`w-max\` makes the wrapper definite (\`width: max-content\`, grow to content) while the injected \`min-width:100%\` keeps it at least the viewport width. With a definite-width parent, the body's \`min-w-full\` resolves: columns fill when narrow and the wrapper still grows + scrolls when there are more columns than fit.

## Testing

- 826 calendar tests pass; type-check, Biome, full build, and the Fallow gate are clean.
- Verified visually in resource month/week vertical (fills + aligns), regular week/day (no regression), and wide resource sets (still scrolls).

See \`docs/logs/2026-06-28.md\` for the full writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)