### PR TITLE
feat(playground): make the demo mobile-responsive

### DIFF
--- a/apps/demo/index.html
+++ b/apps/demo/index.html
@@ -7,6 +7,6 @@
     <script type="module" src="/src/frontend.tsx" async></script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root" style="width: 100%;"></div>
   </body>
 </html>

--- a/apps/demo/src/index.css
+++ b/apps/demo/src/index.css
@@ -15,8 +15,12 @@
     @apply font-sans;
   }
 
+  /* Normal block flow so #root fills the viewport width. The starter's
+   * `grid place-items-center` sized #root to its content (justify-items: center),
+   * which let a wide calendar grow the page and scroll horizontally. The demo's
+   * own `container mx-auto` handles horizontal centering. */
   body {
-    @apply grid place-items-center min-w-[320px] min-h-screen relative m-0 bg-background text-foreground;
+    @apply min-w-[320px] min-h-screen relative m-0 bg-background text-foreground;
   }
 }
 

--- a/apps/website/src/pages/demo.astro
+++ b/apps/website/src/pages/demo.astro
@@ -4,5 +4,8 @@ import MainLayout from '@/layouts/main-layout.astro'
 ---
 
 <MainLayout>
-  <Playground client:only="react" />
+  <!-- The playground is 100% width; the consumer owns the max-width + centering. -->
+  <div class="container mx-auto">
+    <Playground client:only="react" />
+  </div>
 </MainLayout>

--- a/docs/logs/2026-06-28.md
+++ b/docs/logs/2026-06-28.md
@@ -30,6 +30,36 @@
   `all-day-row.test.tsx`, `horizontal-grid-row.test.tsx`, `views/week.test.tsx`,
   `views/day.test.tsx`, `ilamy-calendar.test.tsx`.
 
+- **[playground]**: Made the demo mobile-responsive. The tall settings panel previously
+  stacked above the calendar on small screens, pushing the calendar far down the page. On
+  mobile (`< lg`) the settings now live behind a sticky "Calendar Settings" trigger that opens
+  a scrollable dialog, so the calendar is full-width and immediately visible; at `lg` an inline
+  sidebar takes over. The mobile/desktop switch is pure CSS (`lg:hidden` / `hidden lg:block`),
+  no JS breakpoint hook. The settings form renders in both spots; the fields bind via
+  `useController`, so the two instances safely share one form state, and `FormCheckbox` now
+  derives its id from `useId` so the duplicate mount has no colliding label/control ids.
+
+  Layout/width: the playground root is now `w-full` (always 100% width) instead of
+  `container mx-auto`, so the max-width/centering constraint lives with the consumers (the demo
+  app already wraps it in `container mx-auto`; added the same wrapper to the website's
+  `demo.astro`, which previously had none). The horizontal-scroll-on-mobile root cause was the
+  demo `body`: the Vite/Bun starter set it to `grid place-items-center`, and `place-items-center`
+  implies `justify-items: center`, which sizes the grid item (`#root`) to its content width
+  instead of stretching it to the viewport. So a wide calendar grew `#root` and scrolled the
+  page. Fixed by dropping `grid place-items-center` from `body` (normal block flow → `#root`
+  fills the viewport; the demo's `container mx-auto` already centers horizontally). Belt-and-
+  suspenders: `#root` also carries `width: 100%` in `index.html`. Separately, `overflow-x-clip`
+  on the playground root keeps a wide view (month/week columns have a `min-w-20` floor that can
+  exceed a phone's width) from overflowing its container. `clip` (not `hidden`) is deliberate:
+  per MDN `overflow: clip` is not a scroll container, so it does not hijack the calendar's sticky
+  view header or the sticky settings trigger (which `overflow: hidden` would).
+
+  Desktop sidebar width: switched the `lg` layout from a 4-col grid (settings `col-span-1`,
+  calendar `col-span-3`) to `grid-cols-[20rem_minmax(0,1fr)]` — a fixed 20rem settings sidebar
+  plus a flexible calendar column. The `col-span-1` quarter was too narrow even at ~1250px and
+  truncated the segmented button groups (e.g. Agenda Window's "3-day"). `minmax(0,1fr)` lets the
+  calendar column shrink instead of overflowing the grid.
+
 - **[header]**: Fixed the toolbar flip-flopping between one and two rows at the same width
   when switching views. The row/stack decision now keys off the container width (`flex-col`
   below `@lg`, `flex-row` + `justify-between` at `@lg`+) instead of `flex-wrap`. `flex-wrap`
@@ -56,6 +86,15 @@
 - `packages/calendar/src/lib/constants.ts` - `DISABLED_CELL_CLASSNAME` color-mix shade.
 - `packages/calendar/src/features/calendar/components/header/base-header.tsx` - container-query
   flex-direction (flex-col / @lg:flex-row) instead of flex-wrap for a view-independent toolbar.
+- `packages/playground/src/playground.tsx` - responsive layout (desktop sidebar / mobile
+  settings dialog) switched by CSS, `overflow-x-clip` on the root.
+- `packages/playground/src/components/form/form-checkbox.tsx` - `useId` for a unique
+  label/control id (the settings form mounts twice across breakpoints).
+- `apps/website/src/pages/demo.astro` - wrapped the playground in `container mx-auto` so the
+  website (a consumer) owns the width constraint now that the playground is `w-full`.
+- `apps/demo/src/index.css` - dropped `grid place-items-center` from `body` so `#root` fills
+  the viewport instead of shrink-wrapping to content (the cause of mobile horizontal scroll).
+- `apps/demo/index.html` - `width: 100%` on `#root` (belt-and-suspenders for the above).
 - `packages/calendar/src/features/calendar/components/views/{week,month,month-header,resource-axis,resource-week-vertical-day-header,resource-week-vertical-resource-header,resource-week-horizontal-day-header,time-header-row}.tsx`
   - gap-px headers/arrangements.
 - Tests: `vertical-grid-col.test.tsx`, `all-day-row.test.tsx`, `horizontal-grid-row.test.tsx`,

--- a/packages/playground/src/components/form/form-checkbox.tsx
+++ b/packages/playground/src/components/form/form-checkbox.tsx
@@ -1,4 +1,5 @@
 import { Checkbox } from '@ilamy/ui/components/checkbox'
+import { useId } from 'react'
 import { useController, useFormContext } from 'react-hook-form'
 
 interface FormCheckboxProps {
@@ -10,7 +11,9 @@ interface FormCheckboxProps {
 export function FormCheckbox({ name, label }: FormCheckboxProps) {
 	const { control } = useFormContext()
 	const { field } = useController({ name, control })
-	const id = `form-checkbox-${name}`
+	// useId keeps the label/checkbox association unique even when the settings
+	// panel is mounted twice (mobile dialog + desktop sidebar).
+	const id = useId()
 	return (
 		<div className="flex items-center space-x-2">
 			<Checkbox

--- a/packages/playground/src/playground.tsx
+++ b/packages/playground/src/playground.tsx
@@ -1,7 +1,14 @@
 import './lib/dayjs-locales'
 
 import type { CalendarEvent } from '@ilamy/calendar'
-import { useMemo, useState } from 'react'
+import { Button } from '@ilamy/ui/components/button'
+import {
+	Dialog,
+	DialogContent,
+	DialogTitle,
+	DialogTrigger,
+} from '@ilamy/ui/components/dialog'
+import { type ReactNode, useMemo, useState } from 'react'
 import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { CalendarDisplay } from './components/calendar-display'
 import { CalendarSettings } from './components/calendar-settings'
@@ -9,6 +16,28 @@ import { ResourcePicker } from './components/resource-picker'
 import { dummyEvents } from './lib/seed'
 import { defaultSettings, type PlaygroundSettings } from './types/settings-form'
 import { createResourceEvents, demoResources } from './utils/demo-data'
+
+// On mobile the tall settings panel would push the calendar far down the page, so
+// it lives behind a sticky trigger that opens a scrollable dialog; the calendar
+// stays full-width and immediately visible. Hidden at lg, where the inline sidebar
+// takes over (pure CSS, no JS breakpoint check).
+function MobileSettings({ children }: { children: ReactNode }) {
+	return (
+		<div className="sticky top-2 z-20 mb-4 lg:hidden">
+			<Dialog>
+				<DialogTrigger asChild>
+					<Button className="w-full shadow-lg" size="lg" variant="outline">
+						Calendar Settings
+					</Button>
+				</DialogTrigger>
+				<DialogContent className="max-h-[90dvh] gap-0 overflow-y-auto p-0">
+					<DialogTitle className="sr-only">Calendar Settings</DialogTitle>
+					{children}
+				</DialogContent>
+			</Dialog>
+		</div>
+	)
+}
 
 // The shared interactive calendar demo. One react-hook-form drives every
 // setting; components read what they need from the provider via useWatch.
@@ -52,10 +81,30 @@ export function Playground() {
 		})
 	}
 
+	const settings = (
+		<>
+			<CalendarSettings />
+			{calendarType === 'resource' && (
+				<ResourcePicker
+					onToggleResource={toggleResource}
+					resources={demoResources}
+					selectedResourceIds={selectedResourceIds}
+				/>
+			)}
+		</>
+	)
+
 	return (
 		<FormProvider {...form}>
 			<div
-				className="container mx-auto px-4 py-8 relative"
+				// The playground is always 100% width; consumers (the demo app, the docs
+				// website) own the max-width / centering so the width constraint lives with
+				// them. overflow-x-clip keeps a wide view (e.g. month/week, whose columns
+				// have a min-width floor) from overflowing the viewport and adding a
+				// horizontal page scroll. `clip` (not `hidden`) is deliberate: per MDN it
+				// is not a scroll container, so it leaves the calendar's sticky view header
+				// and the sticky settings trigger resolving against the viewport.
+				className="w-full px-4 py-8 relative overflow-x-clip"
 				data-testid="playground"
 			>
 				<div className="mb-8">
@@ -67,19 +116,20 @@ export function Playground() {
 					</p>
 				</div>
 
-				<div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-					<div className="lg:col-span-1 space-y-6">
-						<CalendarSettings />
-						{calendarType === 'resource' && (
-							<ResourcePicker
-								onToggleResource={toggleResource}
-								resources={demoResources}
-								selectedResourceIds={selectedResourceIds}
-							/>
-						)}
-					</div>
+				{/* Fixed-width settings sidebar + flexible calendar column. A fixed
+				    sidebar keeps the controls comfortable (a `lg:col-span-1` of 4 was too
+				    narrow and truncated the button groups); minmax(0,1fr) lets the calendar
+				    column shrink instead of overflowing the grid. */}
+				<div className="lg:grid lg:grid-cols-[20rem_minmax(0,1fr)] lg:gap-8">
+					{/* Settings appear behind a dialog trigger on mobile and as an inline
+					    sidebar at lg, switched purely by CSS. Both render the same form;
+					    the fields bind via useController, so the two instances safely share
+					    one form state (and each FormCheckbox gets a useId-unique id, so the
+					    duplicate mount has no colliding control ids). */}
+					<MobileSettings>{settings}</MobileSettings>
+					<div className="hidden space-y-6 lg:block">{settings}</div>
 
-					<div className="lg:col-span-3">
+					<div className="min-w-0">
 						<CalendarDisplay
 							activeResources={activeResources}
 							customEvents={customEvents}


### PR DESCRIPTION
## What

Makes the interactive playground demo responsive and fixes the layout/width issues found along the way.

### Mobile
- The tall settings panel previously stacked above the calendar, pushing it far down the page. It now lives behind a sticky **Calendar Settings** trigger that opens a scrollable dialog, so the calendar is full-width and visible at the top.
- At `lg` an inline sidebar takes over. The switch is **pure CSS** (`lg:hidden` / `hidden lg:block`) — the `useIsDesktop` media-query hook was removed.
- The settings form renders in both spots and shares one form state via `useController`; `FormCheckbox` now uses `useId` so the duplicate mount has no colliding label/control ids.

### Width / horizontal-scroll
- Playground root is now `w-full`; consumers own the max-width/centering (added a `container mx-auto` wrapper to the website's `demo.astro`, which had none).
- **Root cause of mobile horizontal scroll:** the demo `body` was `grid place-items-center` (Vite/Bun starter), and `place-items-center` implies `justify-items: center`, which sized `#root` to its content width instead of the viewport. Dropped it → normal block flow.
- `overflow-x-clip` on the playground root keeps a wide view (month/week min-column widths) from overflowing the viewport. `clip` (not `hidden`) is deliberate: per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow) `overflow: clip` is **not** a scroll container, so it doesn't break the calendar's sticky header or the sticky settings trigger.

### Desktop
- Switched the `lg` layout from a 4-col grid (settings `col-span-1` ≈ 25%, too narrow — truncated the button groups) to `grid-cols-[20rem_minmax(0,1fr)]`: a fixed 20rem settings sidebar plus a flexible calendar column.

## Scope
Playground/demo/website only — no changes to the published `@ilamy/calendar` library.

## Testing
`bun run lint`, `bun run type-check`, and the demo build pass. Verified manually at 375px (iPhone SE) and ~1250px.