### PR TITLE
refactor(header): derive date-picker form from view nav metadata, not view name

### DIFF
--- a/docs/logs/2026-06-28.md
+++ b/docs/logs/2026-06-28.md
@@ -2,6 +2,19 @@
 
 ## Changes
 
+- **[header date picker] (refactor/generic-header-date-picker)**: Made the header title /
+  date-picker plugin-agnostic. Core previously hardcoded agenda: a `view === 'agenda'` check, a
+  `getAgendaPickerView()` that knew agenda's window semantics, and a reserved `agenda` title key
+  in `header-date-picker.tsx`. A third-party view named anything else could only get the plain
+  day picker. Replaced all of it with a generic `pickerKind(view)` that derives the picker form
+  from the view's own navigation metadata (`navigationStep` / `navigationUnit`, the same fields
+  that already drive prev/next): a single `day`/`week`/`month`/`year` step borrows that grid's
+  picker + title; any other step (amount > 1, or a custom unit) shows the day picker over the
+  view's `range`. Nothing in core references a view by name now. The agenda plugin and the four
+  built-in views needed NO changes — agenda's existing window→navigationStep mapping flows
+  through the generic path (its three title tests pass unchanged, which is the proof). Documented
+  the picker-derivation on `PluginView.navigationStep`'s JSDoc so plugin authors discover it.
+
 - **[vertical-grid] (merged to main, PR #226)**: Fixed a long-standing resource vertical-grid
   alignment bug where the header columns filled the viewport but the body columns shrank to
   their `min-w-20` floor (left-aligned, empty space on the right). Fix: add `*:w-max` to the
@@ -69,6 +82,15 @@
 
 ## Files Modified
 
+- `packages/calendar/src/features/calendar/components/header/header-date-picker.tsx` - replaced
+  the agenda-specific `getAgendaPickerView` + `view === 'agenda'` branch with a generic
+  `pickerKind(view)` (lookup map) keyed off navigation metadata.
+- `packages/calendar/src/features/calendar/components/header/base-header.test.tsx` - added a
+  `header date picker (plugin-agnostic)` suite: a throwaway `sprint` view proves title/picker are
+  derived from nav metadata (week/month/year/day/range, navigationStep wins, no-metadata
+  fallback, month-grid + year-grid picker opens). Agenda title tests kept (now pass via the
+  generic path).
+- `packages/types/src/index.ts` - documented the picker derivation on `PluginView.navigationStep`.
 - `packages/calendar/src/components/vertical-grid/vertical-grid.tsx` - `*:w-max` on viewport
   (with comment); body uses `gap-px bg-border`.
 - `packages/calendar/src/components/vertical-grid/gutter.tsx` - `STICKY_GUTTER_SHADOW`

--- a/packages/calendar/src/features/calendar/components/header/base-header.test.tsx
+++ b/packages/calendar/src/features/calendar/components/header/base-header.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from 'bun:test'
 import { agendaPlugin } from '@ilamy/calendar-agenda'
-import type { CalendarEvent } from '@ilamy/types'
+import type { CalendarEvent, IlamyPlugin, PluginView } from '@ilamy/types'
 import dayjs from '@ilamy/utils/dayjs'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { CalendarProvider } from '@/features/calendar/contexts/calendar-context/provider'
@@ -166,5 +166,116 @@ describe('Calendar header', () => {
 
 		const title = screen.getByTestId('calendar-title')
 		expect(title).toHaveTextContent('Apr 2026')
+	})
+})
+
+// The header date picker must derive its title + picker form generically from a
+// view's navigation metadata, never from the view's name. These exercise a
+// throwaway third-party view (named 'sprint', not 'agenda') to prove core stays
+// plugin-agnostic: the same nav step that drives prev/next also picks the picker.
+describe('header date picker (plugin-agnostic)', () => {
+	// Apr 15 2026 is a Wednesday; firstDayOfWeek defaults to 0 (Sunday), so its
+	// week is Sun Apr 12 - Sat Apr 18.
+	const at = dayjs('2026-04-15T12:00:00.000Z')
+
+	const StubIcon = () => null
+
+	// A one-view plugin with arbitrary navigation metadata and an optional range.
+	const customViewPlugin = (
+		view: Partial<PluginView> & Pick<PluginView, 'name'>
+	): IlamyPlugin => ({
+		name: `plugin-${view.name}`,
+		views: [{ icon: StubIcon, component: () => null, ...view }],
+	})
+
+	const renderSprint = (view: Partial<PluginView>, providerProps = {}) =>
+		renderHeader([], {
+			initialView: 'sprint',
+			initialDate: at,
+			plugins: [customViewPlugin({ name: 'sprint', ...view })],
+			...providerProps,
+		})
+
+	const titleText = () => screen.getByTestId('calendar-title').textContent ?? ''
+
+	it('titles a week-navigating custom view as a week range', () => {
+		renderSprint({ navigationUnit: 'week' })
+		expect(titleText()).toContain('Apr 12 – 18')
+	})
+
+	it('titles a month-navigating custom view as MMM YYYY', () => {
+		renderSprint({ navigationUnit: 'month' })
+		expect(titleText()).toContain('Apr 2026')
+	})
+
+	it('titles a year-navigating custom view as YYYY', () => {
+		renderSprint({ navigationUnit: 'year' })
+		expect(titleText()).toContain('2026')
+		expect(titleText()).not.toContain('Apr')
+	})
+
+	it('titles a single-day custom view as a single date with weekday', () => {
+		renderSprint({ navigationUnit: 'day' })
+		expect(titleText()).toContain('Wed, Apr 15, 2026')
+	})
+
+	it('titles a multi-day-window custom view as its range', () => {
+		renderSprint({
+			navigationStep: { amount: 3, unit: 'day' },
+			range: (date) => ({ start: date, end: date.add(2, 'day') }),
+		})
+		// A 3-day window Apr 15 - 17: not a single day, not a grid week.
+		expect(titleText()).toContain('Apr 15 – 17')
+	})
+
+	it('treats navigationStep as winning over navigationUnit', () => {
+		// A view that labels itself week but steps a 10-day window is a range.
+		renderSprint({
+			navigationUnit: 'week',
+			navigationStep: { amount: 10, unit: 'day' },
+			range: (date) => ({ start: date, end: date.add(9, 'day') }),
+		})
+		expect(titleText()).toContain('Apr 15 – 24')
+	})
+
+	it('falls back to a single date when a view declares no navigation metadata', () => {
+		renderSprint({})
+		expect(titleText()).toContain('Wed, Apr 15, 2026')
+	})
+
+	it('opens the month grid (not the day calendar) for a month-navigating view', async () => {
+		const onDateChange = mock()
+		renderSprint({ navigationUnit: 'month' }, { onDateChange })
+
+		await act(async () => {
+			fireEvent.click(screen.getByTestId('calendar-title'))
+		})
+		// The month grid shows month buttons; the day calendar would not.
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: 'Sep' }))
+		})
+
+		await waitFor(() => {
+			expect(onDateChange).toHaveBeenCalledTimes(1)
+		})
+		expect(onDateChange.mock.calls[0][0].month()).toBe(8)
+	})
+
+	it('opens the year grid for a year-navigating view', async () => {
+		const onDateChange = mock()
+		renderSprint({ navigationUnit: 'year' }, { onDateChange })
+
+		await act(async () => {
+			fireEvent.click(screen.getByTestId('calendar-title'))
+		})
+		// The year grid lists selectable years; pick the next one.
+		await act(async () => {
+			fireEvent.click(screen.getByRole('button', { name: '2027' }))
+		})
+
+		await waitFor(() => {
+			expect(onDateChange).toHaveBeenCalledTimes(1)
+		})
+		expect(onDateChange.mock.calls[0][0].year()).toBe(2027)
 	})
 })

--- a/packages/calendar/src/features/calendar/components/header/header-date-picker.tsx
+++ b/packages/calendar/src/features/calendar/components/header/header-date-picker.tsx
@@ -1,3 +1,4 @@
+import type { PluginView } from '@ilamy/types'
 import { Button } from '@ilamy/ui/components/button'
 import {
 	Popover,
@@ -19,18 +20,33 @@ interface HeaderDatePickerProps {
 	className?: string
 }
 
-// Agenda mirrors the day/week/month grid view's picker according to its window,
-// read off the view's navigationStep (day -> day, week -> week, month -> month).
-// A custom N-day window has no grid equivalent, so it keeps the day picker and a
-// range title.
-function getAgendaPickerView(
-	step: { amount: number; unit: string } | undefined
-): 'day' | 'week' | 'month' | 'agenda' {
-	const isSingleDayWindow = step?.unit === 'day' && step.amount === 1
-	if (step?.unit === 'month') return 'month'
-	if (step?.unit === 'week') return 'week'
-	if (isSingleDayWindow) return 'day'
-	return 'agenda'
+type PickerKind = 'day' | 'week' | 'month' | 'year' | 'range'
+
+// A single navigation unit maps to that grid's picker; everything else is a range.
+const PICKER_BY_UNIT: Partial<Record<string, PickerKind>> = {
+	day: 'day',
+	week: 'week',
+	month: 'month',
+	year: 'year',
+}
+
+// The title dropdown is a jump-to-date aid, so its picker form (and the title
+// format) follow how far the view navigates — metadata every view already
+// declares for prev/next via `navigationStep` / `navigationUnit`. A view that
+// steps a single day/week/month/year borrows that grid's picker; anything else
+// (a multi-unit or custom window) has no single cell to pick, so it shows the day
+// picker over the view's range. Nothing here references a view by name, so core
+// stays agnostic of agenda or any third-party view. Mirrors the step resolution
+// in use-calendar-navigation.
+function pickerKind(view: PluginView | undefined): PickerKind {
+	const step = view?.navigationStep ?? {
+		amount: 1,
+		unit: view?.navigationUnit ?? 'day',
+	}
+	if (step.amount !== 1) {
+		return 'range'
+	}
+	return PICKER_BY_UNIT[step.unit] ?? 'range'
 }
 
 // The header title doubles as a navigation dropdown: clicking it opens a
@@ -63,26 +79,30 @@ export function HeaderDatePicker({ className }: HeaderDatePickerProps) {
 		setOpen(false)
 	}
 
-	// Agenda borrows the matching grid view's title/picker for its window; a
-	// custom-window agenda keeps the 'agenda' (range + day picker) form.
-	const activeView = getViews().find((v) => v.name === view)
-	const isAgendaView = view === 'agenda'
-	const effectiveView = isAgendaView
-		? getAgendaPickerView(activeView?.navigationStep)
-		: view
+	// Title and picker are keyed by the derived picker kind, not the view name.
+	const kind = pickerKind(getViews().find((v) => v.name === view))
 
-	// Title and picker are keyed by view; unknown views fall back to the day form.
-	const titleByView: Partial<Record<string, string>> = {
+	const titleByKind: Record<PickerKind, string> = {
 		year: currentDate.format('YYYY'),
 		month: currentDate.format('MMM YYYY'),
 		week: formatDateRange(weekStart, weekEnd),
 		day: currentDate.format('ddd, MMM D, YYYY'),
-		// Custom-window agenda: show the listed range, not one day.
-		agenda: formatDateRange(currentRange.start, currentRange.end),
+		// A multi-unit/custom window shows its listed range, not a single day.
+		range: formatDateRange(currentRange.start, currentRange.end),
 	}
-	const title = titleByView[effectiveView] ?? currentDate.format('MMM D, YYYY')
+	const title = titleByKind[kind]
 
-	const contentByView: Partial<Record<string, ReactNode>> = {
+	// Both 'day' and 'range' navigate within days, so both use the day calendar;
+	// only their titles differ.
+	const dayPicker = (
+		<Calendar
+			defaultMonth={currentDate.toDate()}
+			firstDayOfWeek={firstDayOfWeek}
+			onSelect={(d) => d && handleSelect(dayjs(d))}
+			selected={currentDate.toDate()}
+		/>
+	)
+	const contentByKind: Record<PickerKind, ReactNode> = {
 		year: <YearGrid onSelect={handleSelect} selected={currentDate} />,
 		month: <MonthGrid onSelect={handleSelect} selected={currentDate} />,
 		week: (
@@ -94,15 +114,10 @@ export function HeaderDatePicker({ className }: HeaderDatePickerProps) {
 				weekHover
 			/>
 		),
+		day: dayPicker,
+		range: dayPicker,
 	}
-	const content = contentByView[effectiveView] ?? (
-		<Calendar
-			defaultMonth={currentDate.toDate()}
-			firstDayOfWeek={firstDayOfWeek}
-			onSelect={(d) => d && handleSelect(dayjs(d))}
-			selected={currentDate.toDate()}
-		/>
-	)
+	const content = contentByKind[kind]
 
 	return (
 		<Popover onOpenChange={setOpen} open={open}>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -258,6 +258,12 @@ export interface PluginView {
 	 * How far prev/next jumps; defaults to one `navigationUnit`. Custom-duration
 	 * views (a 40-day grid, a 4-day vertical view) set `{ amount: 40, unit: 'day' }`
 	 * so navigation moves a full window.
+	 *
+	 * This also selects the header title/date-picker form (the core derives it
+	 * generically, never by view name): a single `day`/`week`/`month`/`year` step
+	 * borrows that grid's picker and title; any other step (amount > 1, or a custom
+	 * unit) shows the day picker over the view's `range`. A third-party view gets
+	 * the right picker for free just by declaring how it navigates.
 	 */
 	navigationStep?: { amount: number; unit: ManipulateType }
 	/**


### PR DESCRIPTION
## Problem

The header title / date picker hardcoded the agenda plugin in core (`header-date-picker.tsx`):
- a `view === 'agenda'` name check,
- a `getAgendaPickerView()` that encoded agenda's window semantics,
- a reserved `agenda` key in the title map.

So a third-party view named anything else could only ever get the plain day picker + single-date title. Core knew about a specific plugin.

## Fix

Derive the picker form generically from metadata every view already declares for prev/next (`navigationStep` / `navigationUnit`):

```ts
function pickerKind(view): PickerKind {
  const step = view?.navigationStep ?? { amount: 1, unit: view?.navigationUnit ?? 'day' }
  if (step.amount !== 1) return 'range'
  return PICKER_BY_UNIT[step.unit] ?? 'range'   // day/week/month/year → that grid; else range
}
```

The picker is a jump-to-date aid, so its granularity matching how far the view navigates is the correct model, not a workaround. Title and picker are keyed by the derived `kind`, never by view name. **Core no longer references any view by name.**

A single `day`/`week`/`month`/`year` step borrows that grid's picker + title; any other step (amount > 1, or a custom unit) shows the day picker over the view's `range`.

## No changes needed to agenda or built-ins

The four built-in views already declare `navigationUnit`, and agenda already maps its window to `navigationStep`. Both flow through the generic path unchanged. The 3 existing agenda title tests pass **as-is**, which is the proof the behavior stayed identical while becoming generic. Any third-party view now gets the right picker for free.

## Tests

Added a `header date picker (plugin-agnostic)` suite using a throwaway third-party `sprint` view (deliberately not named `agenda`):
- week / month / year / day titles, multi-day-window → range title, `navigationStep` wins over `navigationUnit`, no-metadata → single-date fallback
- picker **content** is generic: month-nav opens the month grid, year-nav opens the year grid, both navigate correctly

Documented the derivation on `PluginView.navigationStep`'s JSDoc for plugin authors.

## Verification
- 835/835 calendar tests pass (18 in the header suite)
- type-check, lint, format clean across all packages
- Fallow CI gate clean

Scope: core + types + tests only. No public API change.