### PR TITLE
fix(navigation): emit one onDateChange when year view changes date and view together

### DIFF
--- a/docs/hooks-and-context.md
+++ b/docs/hooks-and-context.md
@@ -56,7 +56,7 @@ The only hook exported for library consumers. Returns a curated subset of contex
 |--------|-------------|
 | `setCurrentDate(date)` | Jump to a specific date |
 | `selectDate(date)` | Set current date (fires `onDateChange`) |
-| `setView(view)` | Switch view (fires `onViewChange`) |
+| `setView(view, date?)` | Switch view, optionally moving to `date` atomically (fires `onViewChange`, then one `onDateChange`) |
 | `nextPeriod()` | Navigate forward by current view unit |
 | `prevPeriod()` | Navigate backward by current view unit |
 | `today()` | Jump to today |

--- a/docs/logs/2026-07-11.md
+++ b/docs/logs/2026-07-11.md
@@ -6,12 +6,20 @@
 
 - **[docs/AGENTS.md]**: Fixed stale facts that had drifted from the repo (audited every checkable claim). Commands: `bun run test` vs bare `bun test` at root (the latter bypasses per-package happy-dom preloads and fails en masse), lint is Biome (was "oxlint"), `prettier:check/fix` → `format:check`/`format`/`check:fix`, `pre-commit` = `check:fix`, ci = check + build + type-check + test. Layout: plugins moved under `packages/plugins/{recurrence,agenda,drag-to-create}`, added `packages/playground`, `apps/website`, `examples/`. Entry points now include `./plugins/agenda` + `./plugins/drag-to-create`. Recurrence: `recurrence-handler.ts` was split into per-operation files. Public API: recurrence exports (`generateRecurringEvents`, `isRecurringEvent`, `RRule`, …) live on `@ilamy/calendar/plugins/recurrence`, not the core; `CellClickInfo` → `CellInfo`. Counts: 85 translation keys (was 94), ~62 test files (was ~45). `/project:load-context` → `/load-context`. Docs list: added writing-plugins, custom-views, agenda-view, migration-v2, monorepo-architecture.
 
+- **[navigation/year-view]**: Fixed issue #231 — clicking a day (or month title) in the year view emitted two `onDateChange` calls, the last one computed from the stale `currentDate` closure in `handleViewChange`, so consumers loading events via `onDateChange` fetched the wrong range and the day view opened empty. `setView` now accepts an optional target date (`setView(view, date?)`) and applies date + view atomically with a single `onDateChange(targetDate, rangeOfNewView)`. `YearView.navigateToDate` uses it instead of `selectDate(date); setView(view)`. Signature widened in `CalendarNavigationSlice` and `IlamyCalendarApi` (backward compatible — the param is optional). Living docs updated (hooks-and-context, resource-calendar, writing-plugins, v2-plugin-architecture).
+
 ## Files Modified
 
 - `packages/playground/src/types/settings-form.ts` - Added `useCustomOnMoreEventsClick` to `PlaygroundSettings` + `defaultSettings` (false)
 - `packages/playground/src/components/calendar-display.tsx` - `onMoreEventsClick` now resolves to `handleMoreEventsClick` only when the toggle is on
 - `packages/playground/src/components/calendar-settings.tsx` - Added the "Use custom onMoreEventsClick handler" checkbox in the Interaction section
 - `AGENTS.md` - Corrected stale commands, monorepo layout, recurrence paths, public API surface, and counts (see above)
+- `packages/calendar/src/features/calendar/hooks/use-calendar-navigation.ts` - `handleViewChange` takes optional target date; atomic state update + single notification
+- `packages/calendar/src/features/calendar/hooks/use-smart-calendar-context.ts` - Widened `IlamyCalendarApi.setView` signature
+- `packages/calendar/src/features/calendar/components/year-view/year-view.tsx` - `navigateToDate` calls `setView(view, date)`; dropped `selectDate`
+- `packages/calendar/src/features/calendar/hooks/use-calendar-engine.test.ts` - New atomic `setView(view, date)` emission test
+- `packages/calendar/src/features/calendar/components/year-view/year-view.test.tsx` - Two regression tests asserting the emitted `onDateChange` payload on day/month clicks
+- `docs/{hooks-and-context,resource-calendar,writing-plugins,v2-plugin-architecture}.md` - `setView` signature
 
 ## Notes
 

--- a/docs/resource-calendar.md
+++ b/docs/resource-calendar.md
@@ -275,7 +275,7 @@ interface IlamyCalendarApi {
   // Navigation methods
   setCurrentDate: (date: Dayjs) => void
   selectDate: (date: Dayjs) => void
-  setView: (view: CalendarView) => void
+  setView: (view: CalendarView, date?: Dayjs) => void
   nextPeriod: () => void
   prevPeriod: () => void
   today: () => void

--- a/docs/v2-plugin-architecture.md
+++ b/docs/v2-plugin-architecture.md
@@ -163,7 +163,7 @@ export interface IlamyCalendarApi {
   // navigation
   readonly setCurrentDate: (date: Dayjs) => void
   readonly selectDate: (date: Dayjs) => void
-  readonly setView: (view: string) => void
+  readonly setView: (view: string, date?: Dayjs) => void
   readonly nextPeriod: () => void
   readonly prevPeriod: () => void
   readonly today: () => void

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -369,7 +369,7 @@ function MyPluginView() {
     // Navigation
     setCurrentDate,    // (date: Dayjs) => void
     selectDate,        // (date: Dayjs) => void
-    setView,           // (view: string) => void
+    setView,           // (view: string, date?: Dayjs) => void
     nextPeriod,        // () => void
     prevPeriod,        // () => void
     today,             // () => void

--- a/packages/calendar/src/features/calendar/components/year-view/year-view.test.tsx
+++ b/packages/calendar/src/features/calendar/components/year-view/year-view.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import type { CalendarEvent } from '@ilamy/types'
-import dayjs from '@ilamy/utils/dayjs'
+import dayjs, { type Dayjs } from '@ilamy/utils/dayjs'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { CalendarProvider } from '@/features/calendar/contexts/calendar-context/provider'
 import { useSmartCalendarContext } from '@/features/calendar/hooks/use-smart-calendar-context'
@@ -475,6 +475,46 @@ describe('YearView', () => {
 
 			// Should be day view, not month view
 			expect(screen.getByTestId('ctx-view')).toHaveTextContent('day')
+		})
+
+		// Issue #231: consumers loading events from onDateChange must receive the
+		// clicked day's range, not a stale range computed from the previous
+		// date/view. Exactly one emission with the final date + range.
+		test('clicking a day cell emits one onDateChange with the clicked day range', () => {
+			const calls: Array<{ date: Dayjs; range: { start: Dayjs; end: Dayjs } }> =
+				[]
+			renderYearView({
+				initialDate: dayjs('2025-01-15'),
+				onDateChange: (date: Dayjs, range: { start: Dayjs; end: Dayjs }) =>
+					calls.push({ date, range }),
+			})
+
+			fireEvent.click(screen.getByTestId('year-day-2025-03-2025-03-10'))
+
+			expect(calls).toHaveLength(1)
+			const emitted = calls.at(0)
+			expect(emitted?.date.format('YYYY-MM-DD')).toBe('2025-03-10')
+			expect(emitted?.range.start.format('YYYY-MM-DD')).toBe('2025-03-10')
+			expect(emitted?.range.end.format('YYYY-MM-DD')).toBe('2025-03-10')
+		})
+
+		test('clicking a month title emits one onDateChange with the month grid range', () => {
+			const calls: Array<{ date: Dayjs; range: { start: Dayjs; end: Dayjs } }> =
+				[]
+			renderYearView({
+				initialDate: dayjs('2025-01-15'),
+				onDateChange: (date: Dayjs, range: { start: Dayjs; end: Dayjs }) =>
+					calls.push({ date, range }),
+			})
+
+			fireEvent.click(screen.getByTestId('year-month-title-03'))
+
+			expect(calls).toHaveLength(1)
+			const emitted = calls.at(0)
+			expect(emitted?.date.format('YYYY-MM-DD')).toBe('2025-03-01')
+			// March 2025 month grid (6x7, week starts Sunday): Feb 23 – Apr 5
+			expect(emitted?.range.start.format('YYYY-MM-DD')).toBe('2025-02-23')
+			expect(emitted?.range.end.format('YYYY-MM-DD')).toBe('2025-04-05')
 		})
 	})
 

--- a/packages/calendar/src/features/calendar/components/year-view/year-view.tsx
+++ b/packages/calendar/src/features/calendar/components/year-view/year-view.tsx
@@ -27,14 +27,8 @@ interface DayData {
 }
 
 export const YearView = () => {
-	const {
-		currentDate,
-		selectDate,
-		setView,
-		getEventsForDateRange,
-		t,
-		firstDayOfWeek,
-	} = useSmartCalendarContext()
+	const { currentDate, setView, getEventsForDateRange, t, firstDayOfWeek } =
+		useSmartCalendarContext()
 	const currentYear = currentDate.year()
 
 	const weekdayHeaders = getWeekDays(dayjs(), firstDayOfWeek).map((d) => ({
@@ -90,8 +84,9 @@ export const YearView = () => {
 		event?: React.MouseEvent
 	) => {
 		event?.stopPropagation()
-		selectDate(date)
-		setView(view)
+		// Atomic date + view change: one onDateChange with the clicked day's
+		// range in the target view (issue #231).
+		setView(view, date)
 	}
 
 	const getEventCountLabel = (count: number): string => {

--- a/packages/calendar/src/features/calendar/hooks/use-calendar-engine.test.ts
+++ b/packages/calendar/src/features/calendar/hooks/use-calendar-engine.test.ts
@@ -341,6 +341,29 @@ describe('useCalendarEngine', () => {
 			expect(range.end.format('YYYY-MM-DD')).toBe('2025-07-12')
 		})
 
+		it('setView with a target date updates date and view atomically and emits one onDateChange', () => {
+			const onDateChange = vi.fn()
+			const initialDate = dayjs('2025-01-15')
+			const { result } = renderHook(() =>
+				useCalendarEngine({
+					...defaultConfig,
+					initialDate,
+					initialView: 'year',
+					onDateChange,
+				})
+			)
+
+			act(() => result.current.setView('day', dayjs('2025-03-10')))
+
+			expect(result.current.view).toBe('day')
+			expect(result.current.currentDate.format('YYYY-MM-DD')).toBe('2025-03-10')
+			expect(onDateChange).toHaveBeenCalledTimes(1)
+			const [calledDate, range] = onDateChange.mock.calls[0]
+			expect(calledDate.format('YYYY-MM-DD')).toBe('2025-03-10')
+			expect(range.start.format('YYYY-MM-DD')).toBe('2025-03-10')
+			expect(range.end.format('YYYY-MM-DD')).toBe('2025-03-10')
+		})
+
 		it('navigates by navigationStep and reports the custom range for views that declare them', () => {
 			const onDateChange = vi.fn()
 			const initialDate = dayjs('2025-01-15T00:00:00.000Z')

--- a/packages/calendar/src/features/calendar/hooks/use-calendar-navigation.ts
+++ b/packages/calendar/src/features/calendar/hooks/use-calendar-navigation.ts
@@ -29,10 +29,11 @@ export interface CalendarNavigationSlice {
 	setCurrentDate: React.Dispatch<React.SetStateAction<Dayjs>>
 	view: CalendarView
 	/**
-	 * Switches the view. Side effects: fires `onViewChange(newView)`, then
-	 * `onDateChange(currentDate, range)` because the visible range changes.
+	 * Switches the view, optionally moving to `date` in the same update so both
+	 * settle atomically. Side effects: fires `onViewChange(newView)`, then one
+	 * `onDateChange(date ?? currentDate, range)` because the visible range changes.
 	 */
-	setView: (view: CalendarView) => void
+	setView: (view: CalendarView, date?: Dayjs) => void
 	selectDate: (date: Dayjs) => void
 	nextPeriod: () => void
 	prevPeriod: () => void
@@ -110,16 +111,23 @@ export const useCalendarNavigation = ({
 	)
 
 	const handleViewChange = useCallback(
-		(newView: CalendarView) => {
+		(newView: CalendarView, date?: Dayjs) => {
+			// When a target date accompanies the view change (e.g. year view day
+			// click), apply both before notifying so consumers never observe a
+			// range computed from the previous date (issue #231).
+			const targetDate = date ?? currentDate
+			if (date) {
+				setCurrentDate(date)
+			}
 			setView(newView)
 			onViewChange?.(newView)
 			// View change affects visible range — notify consumers
 			const range = calculateViewRange(
-				currentDate,
+				targetDate,
 				resolveViewSpec(newView),
 				firstDayOfWeek
 			)
-			onDateChange?.(currentDate, range)
+			onDateChange?.(targetDate, range)
 		},
 		[onViewChange, onDateChange, currentDate, firstDayOfWeek, resolveViewSpec]
 	)

--- a/packages/calendar/src/features/calendar/hooks/use-smart-calendar-context.ts
+++ b/packages/calendar/src/features/calendar/hooks/use-smart-calendar-context.ts
@@ -51,7 +51,8 @@ export interface IlamyCalendarApi {
 	readonly orientation: 'horizontal' | 'vertical'
 	readonly setCurrentDate: (date: Dayjs) => void
 	readonly selectDate: (date: Dayjs) => void
-	readonly setView: (view: CalendarView) => void
+	/** Switch view; pass `date` to move there atomically in the same update. */
+	readonly setView: (view: CalendarView, date?: Dayjs) => void
 	readonly nextPeriod: () => void
 	readonly prevPeriod: () => void
 	readonly today: () => void


### PR DESCRIPTION
## Summary

Fixes #231. Clicking a day (or month title) in the year view opened the target view with the right internal state, but consumers loading events via `onDateChange` received the wrong visible range, so the day view appeared empty until the user navigated away and back.

## Root cause

`YearView.navigateToDate` called `selectDate(date)` then `setView(view)` as two separate operations, producing two `onDateChange` emissions:

1. `selectDate(clickedDay)` — clicked day, but the **old view's** (year) range
2. `setView('day')` — day range, but computed from the **stale** `currentDate` closure in `handleViewChange` (React state hadn't re-rendered yet)

The final emission therefore described the *previous* date's day range. Consumers fetching events from `onDateChange` loaded the wrong day.

## Fix

`setView` now accepts an optional target date: `setView(view, date?)`. When provided, `handleViewChange` applies date + view in the same update and emits a single `onDateChange(targetDate, rangeOfNewView)` — exactly the atomic behavior the issue suggested. The year view uses `setView('day', clickedDay)`.

Backward compatible: the parameter is optional, so existing `setView(view)` callers (header view switcher, consumer code via `IlamyCalendarApi`) are unchanged. Docs updated where the signature is documented.

## Testing (TDD)

Tests written first and confirmed failing against the unfixed code (both clicks emitted 2 calls with the stale range last):

- engine: `setView('day', date)` from year view updates date+view atomically and emits exactly one `onDateChange` with the day's `startOf/endOf` range
- year-view: day click emits one call with the clicked day's range; month-title click emits one call with the month grid range

Full validation: calendar 841 pass, recurrence 165, drag-to-create 56, agenda 19; build clean; type-check 0 errors; Biome clean.

Closes #231