### PR TITLE
docs: document post-v2 API additions on website and fix stale defaults

### DIFF
--- a/apps/website/src/content/docs/components/calendar.mdx
+++ b/apps/website/src/content/docs/components/calendar.mdx
@@ -113,11 +113,12 @@ The only valid import entry points are `@ilamy/calendar`, `@ilamy/calendar/plugi
 | `onCellClick` | `(info: CellInfo) => void` | Called when a date cell is clicked. Receives a CellInfo object with start, end, and optional resource (the full resource object in resource calendars). |
 | `isCellDisabled` | `(info: CellInfo) => boolean` | Return `true` to disable a cell: blocks event-creation clicks, rejects drops onto the cell, and grays it out. Composes with `businessHours` via OR (a cell is disabled if business hours OR `isCellDisabled` disables it). |
 | `getCellClassName` | `(info: CellInfo) => string` | Return extra CSS classes for a cell from custom logic (unavailability styling, on-call windows, etc.). Receives the same `CellInfo` as `onCellClick`. Unlike `isCellDisabled`, this is purely visual: cells stay clickable and keep accepting drops. Return `''` for cells you do not want to style. |
-| `onViewChange` | `(view: 'month' \| 'week' \| 'day' \| 'year') => void` | Called when the calendar view changes |
+| `onMoreEventsClick` | `(day: dayjs.Dayjs, events: CalendarEvent[]) => void` | Called when the "+N more" overflow indicator in a day cell is clicked, receiving the cell's day and its full event list. When provided, it replaces the built-in all-events dialog. See [More Events Overflow](/docs/customization/components#more-events-overflow). |
+| `onViewChange` | `(view: CalendarView) => void` | Called when the calendar view changes. `CalendarView` is `string` in v2, so plugin views (e.g. `'agenda'`) are included |
 | `onEventAdd` | `(event: CalendarEvent) => void` | Called when a new event is created |
 | `onEventUpdate` | `(event: CalendarEvent) => void` | Called when an existing event is updated |
 | `onEventDelete` | `(event: CalendarEvent) => void` | Called when an event is deleted |
-| `onDateChange` | `(date: dayjs.Dayjs, range: { start: dayjs.Dayjs; end: dayjs.Dayjs }) => void` | Called when the calendar date changes or the view changes. The `range` contains the visible date range for the current view. |
+| `onDateChange` | `(date: dayjs.Dayjs, range: { start: dayjs.Dayjs; end: dayjs.Dayjs }) => void` | Called when the calendar date changes or the view changes. The `range` contains the visible date range for the current view. When date and view change together (e.g. clicking a day in the year view), it fires once with the final date and range. |
 
 ## Examples
 

--- a/apps/website/src/content/docs/components/use-ilamy-calendar-context.mdx
+++ b/apps/website/src/content/docs/components/use-ilamy-calendar-context.mdx
@@ -69,7 +69,7 @@ The hook returns an object with the following properties and methods:
 | `firstDayOfWeek` | `number` | The first day of the week (0 = Sunday) |
 | `setCurrentDate` | `(date: Dayjs) => void` | Navigate to a specific date/month |
 | `selectDate` | `(date: Dayjs) => void` | Select a specific date |
-| `setView` | `(view: CalendarView) => void` | Change the current view |
+| `setView` | `(view: CalendarView, date?: Dayjs) => void` | Change the current view. Pass `date` to also move there in the same update, firing a single `onDateChange` with the new view's range |
 | `nextPeriod` | `() => void` | Navigate to the next period |
 | `prevPeriod` | `() => void` | Navigate to the previous period |
 | `today` | `() => void` | Navigate to today's date |

--- a/apps/website/src/content/docs/customization/components.mdx
+++ b/apps/website/src/content/docs/customization/components.mdx
@@ -116,6 +116,23 @@ The event object passed to your custom renderer includes:
 - `allDay` - Whether it's an all-day event
 - `data` - Any custom properties you include in your event data
 
+## More Events Overflow
+
+When a day cell holds more events than `dayMaxEvents` (default `4`), the calendar renders a "+N more" indicator. Clicking it opens the built-in all-events dialog. Provide `onMoreEventsClick` to replace that dialog with your own UI:
+
+```tsx
+<IlamyCalendar
+  events={events}
+  dayMaxEvents={3}
+  onMoreEventsClick={(day, events) => {
+    // day: the cell's day (Dayjs); events: all events for that day
+    openDayDrawer(day, events);
+  }}
+/>
+```
+
+When the callback is provided, the built-in dialog never opens. Omit it to keep the default behavior.
+
 ## Styling Tips
 
 :::tip[Pro Tips]

--- a/docs/logs/2026-07-12.md
+++ b/docs/logs/2026-07-12.md
@@ -4,9 +4,15 @@
 
 - **[tests/engine]**: Addressed code-review findings on PR #234 (test-only). Extracted the repeated engine + `onDateChange` spy setup in the three sequencing tests into a local `renderNavEngine(initialView)` helper (mirroring the file's `renderRecurrenceEngine` pattern), plus an `expectSecondEmissionDay(onDateChange, isoDay)` helper for the duplicated last-emission assertion block. Replaced `mock.calls[1]` bracket access with `mock.calls.at(1) ?? []` + optional-chained assertions per the code-style `.at()` rule.
 
+- **[docs/website]**: Documented the post-v2.0.0 API changes on both doc surfaces. Website: added `onMoreEventsClick` to the calendar Event Handlers table (#230), a "More Events Overflow" section with example in customization/components, the `setView(view, date?)` signature + atomic-navigation note on the context page (#233/#234), a single-emission note on `onDateChange`, and fixed the `onViewChange` type (v1 view union → `CalendarView` string, which includes plugin views). Repo docs: corrected `dayMaxEvents` default in types-and-interfaces.md (`3` → `4`, actual `DAY_MAX_EVENTS_DEFAULT` in lib/constants.ts).
+
 ## Files Modified
 
 - `packages/calendar/src/features/calendar/hooks/use-calendar-engine.test.ts` - `renderNavEngine` + `expectSecondEmissionDay` helpers; `.at(1)` access; added `CalendarView` type import
+- `apps/website/src/content/docs/components/calendar.mdx` - `onMoreEventsClick` row, `onViewChange` type fix, `onDateChange` atomic note
+- `apps/website/src/content/docs/components/use-ilamy-calendar-context.mdx` - `setView(view, date?)` signature
+- `apps/website/src/content/docs/customization/components.mdx` - New "More Events Overflow" section
+- `docs/types-and-interfaces.md` - `dayMaxEvents` default `3` → `4`
 
 ## Notes
 

--- a/docs/types-and-interfaces.md
+++ b/docs/types-and-interfaces.md
@@ -114,7 +114,7 @@ Top-level props for `<IlamyCalendar>`. Key props summarized below — see source
 | `disableCellClick` | `boolean` | — | Disable cell clicks |
 | `disableEventClick` | `boolean` | — | Disable event clicks |
 | `disableDragAndDrop` | `boolean` | — | Disable DnD |
-| `dayMaxEvents` | `number` | `3` | Max events per day in month view |
+| `dayMaxEvents` | `number` | `4` | Max events per day in month view |
 | `onMoreEventsClick` | `(day: Dayjs, events: CalendarEvent[]) => void` | — | Called when the "+N more" overflow indicator is clicked, with the cell's day and full event list. Overrides the built-in all-events dialog when provided |
 | `eventSpacing` | `number` | `1` | Gap between stacked events (px) |
 | `stickyViewHeader` | `boolean` | `true` | Sticky day/week headers |


### PR DESCRIPTION
## Summary

Audit of both doc surfaces against every commit since the v2.0.0 tag. Two public API changes were undocumented on the website, and the sweep surfaced two pre-existing inaccuracies.

## Website

- `components/calendar.mdx`: added `onMoreEventsClick` to the Event Handlers table (#230) with a cross-link to the new customization section; noted on `onDateChange` that combined date+view changes fire once with the final date and range (#233/#234); fixed `onViewChange`'s type, which still showed the v1 `'month' | 'week' | 'day' | 'year'` union instead of v2's `CalendarView` string (source: `types/index.ts:166`)
- `components/use-ilamy-calendar-context.mdx`: `setView` signature updated to `(view: CalendarView, date?: Dayjs) => void` with the atomic-move description
- `customization/components.mdx`: new "More Events Overflow" section documenting the `dayMaxEvents` → "+N more" → dialog flow and the `onMoreEventsClick` override, with example

## Repo docs

- `types-and-interfaces.md`: `dayMaxEvents` default corrected `3` → `4` (matches `DAY_MAX_EVENTS_DEFAULT` in `lib/constants.ts`)

## Validation

Website builds clean (26 pages).