### PR TITLE
fix(views): animate header labels instead of whole cells, drop staggering

### DIFF
--- a/docs/logs/2026-07-27.md
+++ b/docs/logs/2026-07-27.md
@@ -1,0 +1,33 @@
+# Development Log - 2026-07-27
+
+## Changes
+
+- **[views/headers]**: View headers now animate only their label, not the whole cell. Previously `AnimatedSection` **was** the header cell, so it carried `bg-background`, `flex-1`, padding and hover styles, and the entire cell slid and faded in on every navigation. The year view read better because its `AnimatedSection` sits inside the month card wrapping only the title row, leaving the card's border, background and padding static. Every header now follows that shape: a plain cell element holding layout, background, `data-testid` and click handler, with `AnimatedSection` inside wrapping just the `DayLabel` / `HourLabel` / weekday span.
+
+- **[animations]**: Removed staggering everywhere, including the year grid, so all animated elements enter together. `TimeHeaderRow` lost its `delayStep` prop, and both `HEADER_STAGGER_DELAY` and `HOUR_STAGGER_DELAY` are deleted (the latter existed only so a 168-cell hour row would not cascade for ~8s). Enter duration raised from 200ms to 500ms in `AnimatedSection`.
+
+## Files Modified
+
+- `packages/calendar/src/components/animations/animated-section.tsx` - `duration-200` to `duration-500`
+- `packages/calendar/src/features/calendar/components/views/month-header.tsx` - static cell, animated weekday span
+- `packages/calendar/src/features/calendar/components/views/week.tsx` - static clickable day cell, animated `DayLabel`; dropped `delayStep`
+- `packages/calendar/src/features/calendar/components/views/day.tsx` - dropped `delayStep`
+- `packages/calendar/src/features/calendar/components/views/time-header-row.tsx` - static hour cell, animated `HourLabel` with `text-center`, removed the `delayStep` prop
+- `packages/calendar/src/features/calendar/components/views/month.tsx` - static resource month day cell, animated `DayLabel`
+- `packages/calendar/src/features/calendar/components/views/resource-week-vertical-day-header.tsx` - static cell, animated `DayLabel`
+- `packages/calendar/src/features/calendar/components/views/resource-week-horizontal-day-header.tsx` - static cell, animated inner wrapper
+- `packages/calendar/src/features/calendar/components/year-view/year-view.tsx` - dropped the per-card stagger
+- `packages/calendar/src/lib/constants.ts` - removed both stagger constants
+- `packages/calendar/src/features/calendar/components/views/{month,week}.test.tsx` - assert the cell has no `animate-in`, an inner element does, and `animationDelay` is `0s`
+
+## Notes
+
+Regression caught during review and worth remembering: `HourLabel` renders a bare text node with no element of its own, so it inherits alignment from whatever box wraps it. Moving `AnimatedSection` inside the hour cell put a `w-full` wrapper between cell and text, which made the cell's `justify-center` a no-op and left the hour labels pinned to the left edge of every column in the resource horizontal views. Fixed by putting `text-center` on the animated wrapper. `DayLabel` is immune because it centers its own content (`flex flex-col items-center` plus `text-center` on the weekday), which is why only the hour row broke.
+
+`AnimatedSection` itself is otherwise untouched. Its `delay` prop is now unused but kept, since the component is shared by the view container, the year cards and event mounts, and reworking a shared component during a visual fix invites exactly the kind of regression above.
+
+The 500ms duration lives in `AnimatedSection`, so it applies to all four consumers: header labels, the view-switch fade, year cards, and every event mount. If event mounts feel slow, the narrower fix is to keep the component at 200ms and pass `duration-500` per call site, which works because `cn` uses `twMerge` and a passed duration overrides the default.
+
+`duration-500` was verified to actually generate rather than silently falling back to the plugin's 150ms default: the built demo CSS contains `animation-duration:.5s`. The `tailwindcss-animate` plugin maps `duration-*` to `animationDuration` from `{0, ...theme('transitionDuration')}`.
+
+The week day header keeps its click-to-create behavior as a `div` with two `biome-ignore` lines rather than becoming a `button`, since that would change default styling and focus semantics.

--- a/packages/calendar/src/components/animations/animated-section.tsx
+++ b/packages/calendar/src/components/animations/animated-section.tsx
@@ -35,7 +35,7 @@ export const AnimatedSection: React.FC<AnimatedSectionProps> = ({
 	return (
 		<div
 			className={cn(
-				'inline-block w-full animate-in fade-in fill-mode-backwards duration-200 ease-in-out',
+				'inline-block w-full animate-in fade-in fill-mode-backwards duration-500 ease-in-out',
 				slideInClass,
 				className
 			)}

--- a/packages/calendar/src/features/calendar/components/views/day.tsx
+++ b/packages/calendar/src/features/calendar/components/views/day.tsx
@@ -18,7 +18,6 @@ import {
 	collectResourceBusinessHours,
 	getViewHours,
 } from '@/features/calendar/utils/view-hours'
-import { HEADER_STAGGER_DELAY } from '@/lib/constants'
 import { getDayKey, isToday } from '@/lib/utils/date-utils'
 import { keys } from '@/lib/utils/keys'
 import {
@@ -76,11 +75,7 @@ const ResourceDayHorizontalHeader: React.FC<{
 		<>
 			<ResourcesCornerCell />
 			<div className="flex-1 flex flex-col">
-				<TimeHeaderRow
-					delayStep={HEADER_STAGGER_DELAY}
-					hours={hours}
-					view="day"
-				/>
+				<TimeHeaderRow hours={hours} view="day" />
 			</div>
 		</>
 	)

--- a/packages/calendar/src/features/calendar/components/views/month-header.tsx
+++ b/packages/calendar/src/features/calendar/components/views/month-header.tsx
@@ -2,7 +2,6 @@ import { cn } from '@ilamy/ui/lib/utils'
 import type React from 'react'
 import { AnimatedSection } from '@/components/animations/animated-section'
 import { useSmartCalendarContext } from '@/features/calendar/hooks/use-smart-calendar-context'
-import { HEADER_STAGGER_DELAY } from '@/lib/constants'
 import { getWeekDays } from '@/lib/utils/date-utils'
 import { keys } from '@/lib/utils/keys'
 
@@ -28,18 +27,18 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({ className }) => {
 			)}
 			data-testid="month-header"
 		>
-			{weekDays.map((weekDay, index) => (
-				<AnimatedSection
+			{weekDays.map((weekDay) => (
+				<div
 					className="py-2 text-center font-medium bg-background flex-1 min-w-0"
 					data-testid={keys.header.weekday('month', weekDay.format('ddd'))}
-					delay={index * HEADER_STAGGER_DELAY}
 					key={weekDay.toISOString()}
-					transitionKey={weekDay.toISOString()}
 				>
-					<span className="text-sm capitalize truncate w-full block">
-						{weekDay.format('ddd')}
-					</span>
-				</AnimatedSection>
+					<AnimatedSection transitionKey={weekDay.toISOString()}>
+						<span className="text-sm capitalize truncate w-full block">
+							{weekDay.format('ddd')}
+						</span>
+					</AnimatedSection>
+				</div>
 			))}
 		</div>
 	)

--- a/packages/calendar/src/features/calendar/components/views/month.test.tsx
+++ b/packages/calendar/src/features/calendar/components/views/month.test.tsx
@@ -90,6 +90,21 @@ describe('MonthView', () => {
 		})
 	})
 
+	test('animates the weekday label only, leaving the header cell static', () => {
+		cleanup()
+		renderMonthView()
+
+		const cell = screen.getByTestId('month-header-weekday-mon')
+		const animated = cell.querySelector('.animate-in')
+
+		// The cell keeps its background and layout; only the text inside enters,
+		// matching the year view. No stagger.
+		expect(cell.className).not.toContain('animate-in')
+		expect(animated).not.toBeNull()
+		expect(animated?.textContent).toBe('Mon')
+		expect((animated as HTMLElement).style.animationDelay).toBe('0s')
+	})
+
 	test('renders MonthView with correct weekday headers starting from Monday', () => {
 		cleanup() // Clean up previous renders
 		const { container } = renderMonthView({ firstDayOfWeek: 1 }) // Set Monday as first day of week

--- a/packages/calendar/src/features/calendar/components/views/month.tsx
+++ b/packages/calendar/src/features/calendar/components/views/month.tsx
@@ -11,7 +11,6 @@ import { Grid3x3 } from 'lucide-react'
 import type React from 'react'
 import { AnimatedSection } from '@/components/animations/animated-section'
 import { gutterColumn } from '@/components/vertical-grid/gutter'
-import { HEADER_STAGGER_DELAY } from '@/lib/constants'
 import {
 	getMonthDays,
 	getMonthGridRange,
@@ -67,19 +66,19 @@ const ResourceMonthHorizontalHeader: React.FC<{ date: Dayjs }> = ({ date }) => {
 					const today = isToday(day)
 
 					return (
-						<AnimatedSection
+						<div
 							className="flex-1 w-20 bg-background shrink-0 flex items-center justify-center flex-col"
-							delay={index * HEADER_STAGGER_DELAY}
-							key={keys.listKey(key, 'animated')}
-							transitionKey={keys.listKey(key, 'motion')}
+							key={key}
 						>
-							<DayLabel
-								className="flex-col-reverse"
-								dayNumber={day.format('D')}
-								today={today}
-								weekday={day.format('ddd')}
-							/>
-						</AnimatedSection>
+							<AnimatedSection transitionKey={key}>
+								<DayLabel
+									className="flex-col-reverse"
+									dayNumber={day.format('D')}
+									today={today}
+									weekday={day.format('ddd')}
+								/>
+							</AnimatedSection>
+						</div>
 					)
 				})}
 			</div>

--- a/packages/calendar/src/features/calendar/components/views/resource-week-horizontal-day-header.tsx
+++ b/packages/calendar/src/features/calendar/components/views/resource-week-horizontal-day-header.tsx
@@ -4,7 +4,7 @@ import type { Dayjs } from '@ilamy/utils/dayjs'
 import type React from 'react'
 import { AnimatedSection } from '@/components/animations/animated-section'
 import { useSmartCalendarContext } from '@/features/calendar/hooks/use-smart-calendar-context'
-import { HEADER_ROW_HEIGHT, HEADER_STAGGER_DELAY } from '@/lib/constants'
+import { HEADER_ROW_HEIGHT } from '@/lib/constants'
 import { isToday } from '@/lib/utils/date-utils'
 import { keys } from '@/lib/utils/keys'
 
@@ -25,27 +25,26 @@ export const ResourceWeekHorizontalDayHeader: React.FC<
 				const key = keys.header.week.day(day)
 
 				return (
-					<AnimatedSection
+					<div
 						className={cn(
 							'shrink-0 bg-background flex-1 flex items-center text-center font-medium min-w-20'
 						)}
 						data-testid={keys.header.resource.weekDay}
-						delay={index * HEADER_STAGGER_DELAY}
-						key={keys.listKey(key, 'animated')}
-						transitionKey={keys.listKey(key, 'motion')}
+						key={key}
 					>
-						<div
+						<AnimatedSection
 							className={cn(
 								isHourly ? 'sticky left-1/2' : 'w-full text-center'
 							)}
+							transitionKey={key}
 						>
 							<DayLabel
 								dayNumber={day.format('D')}
 								today={today}
 								weekday={day.format('ddd')}
 							/>
-						</div>
-					</AnimatedSection>
+						</AnimatedSection>
+					</div>
 				)
 			})}
 		</div>

--- a/packages/calendar/src/features/calendar/components/views/resource-week-vertical-day-header.tsx
+++ b/packages/calendar/src/features/calendar/components/views/resource-week-vertical-day-header.tsx
@@ -8,7 +8,6 @@ import {
 	STICKY_GUTTER_SHADOW,
 } from '@/components/vertical-grid/gutter'
 import { useSmartCalendarContext } from '@/features/calendar/hooks/use-smart-calendar-context'
-import { HEADER_STAGGER_DELAY } from '@/lib/constants'
 import { isToday } from '@/lib/utils/date-utils'
 import { keys } from '@/lib/utils/keys'
 import { RESOURCE_CELL_WIDTH } from './resource-axis'
@@ -42,7 +41,7 @@ export const ResourceWeekVerticalDayHeader: React.FC<
 				const key = keys.header.week.hour(day, col.resourceId ?? '')
 
 				return (
-					<AnimatedSection
+					<div
 						className={cn(
 							RESOURCE_CELL_WIDTH,
 							'flex flex-col items-center justify-center text-xs shrink-0 bg-background'
@@ -51,16 +50,16 @@ export const ResourceWeekVerticalDayHeader: React.FC<
 							'week',
 							day.format('HH')
 						)}
-						delay={index * HEADER_STAGGER_DELAY}
-						key={keys.listKey(key, 'animated')}
-						transitionKey={keys.listKey(key, 'motion')}
+						key={key}
 					>
-						<DayLabel
-							dayNumber={day.format('D')}
-							today={today}
-							weekday={day.format('ddd')}
-						/>
-					</AnimatedSection>
+						<AnimatedSection transitionKey={key}>
+							<DayLabel
+								dayNumber={day.format('D')}
+								today={today}
+								weekday={day.format('ddd')}
+							/>
+						</AnimatedSection>
+					</div>
 				)
 			})}
 		</div>

--- a/packages/calendar/src/features/calendar/components/views/time-header-row.tsx
+++ b/packages/calendar/src/features/calendar/components/views/time-header-row.tsx
@@ -10,16 +10,11 @@ import { RESOURCE_CELL_WIDTH } from './resource-axis'
 interface TimeHeaderRowProps {
 	hours: Dayjs[]
 	view: 'week' | 'day'
-	// Per-item animation delay. Callers pass different step constants depending
-	// on the list length (HOUR_STAGGER_DELAY for a week of hours,
-	// HEADER_STAGGER_DELAY for a single day).
-	delayStep: number
 }
 
 export const TimeHeaderRow: React.FC<TimeHeaderRowProps> = ({
 	hours,
 	view,
-	delayStep,
 }) => (
 	<div className={cn('flex gap-px bg-border border-b', HEADER_ROW_HEIGHT)}>
 		{hours.map((col, index) => {
@@ -27,7 +22,7 @@ export const TimeHeaderRow: React.FC<TimeHeaderRowProps> = ({
 			const hourStr = col.format('HH')
 			const key = keys.header.week.hour(col, index)
 			return (
-				<AnimatedSection
+				<div
 					className={cn(
 						RESOURCE_CELL_WIDTH,
 						'bg-background flex items-center justify-center text-xs shrink-0',
@@ -35,12 +30,14 @@ export const TimeHeaderRow: React.FC<TimeHeaderRowProps> = ({
 					)}
 					data-hour={hourStr}
 					data-testid={keys.header.resource.timeLabel(view, hourStr)}
-					delay={index * delayStep}
-					key={keys.listKey(key, 'animated')}
-					transitionKey={keys.listKey(key, 'motion')}
+					key={key}
 				>
-					<HourLabel date={col} />
-				</AnimatedSection>
+					{/* `HourLabel` renders bare text, so the animated wrapper has to
+					    carry the centering the cell used to apply directly. */}
+					<AnimatedSection className="text-center" transitionKey={key}>
+						<HourLabel date={col} />
+					</AnimatedSection>
+				</div>
 			)
 		})}
 	</div>

--- a/packages/calendar/src/features/calendar/components/views/week.test.tsx
+++ b/packages/calendar/src/features/calendar/components/views/week.test.tsx
@@ -100,6 +100,20 @@ describe('WeekView', () => {
 		})
 	})
 
+	test('animates the day label only, leaving the header cell static', () => {
+		cleanup()
+		renderWeekView()
+
+		const cell = screen.getByTestId('week-header-weekday-sunday')
+		const animated = cell.querySelector('.animate-in')
+
+		// The clickable cell keeps its background and hover styling; only the
+		// label inside enters, matching the year view. No stagger.
+		expect(cell.className).not.toContain('animate-in')
+		expect(animated).not.toBeNull()
+		expect((animated as HTMLElement).style.animationDelay).toBe('0s')
+	})
+
 	test('renders WeekView with correct weekday headers starting from Monday', () => {
 		cleanup() // Clean up previous renders
 		renderWeekView({ firstDayOfWeek: 1 }) // Set Monday as first day of week

--- a/packages/calendar/src/features/calendar/components/views/week.tsx
+++ b/packages/calendar/src/features/calendar/components/views/week.tsx
@@ -21,7 +21,6 @@ import {
 	collectResourceBusinessHours,
 	getViewHours,
 } from '@/features/calendar/utils/view-hours'
-import { HEADER_STAGGER_DELAY, HOUR_STAGGER_DELAY } from '@/lib/constants'
 import { getWeekDays, isToday } from '@/lib/utils/date-utils'
 import { keys } from '@/lib/utils/keys'
 import {
@@ -85,25 +84,27 @@ const WeekViewHeader: React.FC<{ date: Dayjs; config: ViewConfig }> = ({
 				const key = keys.header.week.day(day)
 
 				return (
-					<AnimatedSection
+					// biome-ignore lint/a11y/noStaticElementInteractions: day header is clickable, unchanged behavior
+					// biome-ignore lint/a11y/useKeyWithClickEvents: keyboard access is handled by the day cells
+					<div
 						className={cn(
 							'hover:bg-accent bg-background flex-1 min-w-0 flex flex-col justify-center cursor-pointer p-1 text-center sm:p-2 w-20 h-full'
 						)}
 						data-testid={keys.header.weekday('week', day.format('dddd'))}
-						delay={index * HEADER_STAGGER_DELAY}
 						key={key}
 						onClick={() => {
 							selectDate(day)
 							openEventForm({ start: day })
 						}}
-						transitionKey={key}
 					>
-						<DayLabel
-							dayNumber={day.format('D')}
-							today={today}
-							weekday={day.format('ddd')}
-						/>
-					</AnimatedSection>
+						<AnimatedSection transitionKey={key}>
+							<DayLabel
+								dayNumber={day.format('D')}
+								today={today}
+								weekday={day.format('ddd')}
+							/>
+						</AnimatedSection>
+					</div>
 				)
 			})}
 		</div>
@@ -237,13 +238,7 @@ const ResourceWeekHorizontalHeader: React.FC<{
 			<ResourcesCornerCell />
 			<div className="flex-1 flex flex-col">
 				<ResourceWeekHorizontalDayHeader days={weekDays} />
-				{isHourly && (
-					<TimeHeaderRow
-						delayStep={HOUR_STAGGER_DELAY}
-						hours={weekHours}
-						view="week"
-					/>
-				)}
+				{isHourly && <TimeHeaderRow hours={weekHours} view="week" />}
 			</div>
 		</>
 	)

--- a/packages/calendar/src/features/calendar/components/year-view/year-view.tsx
+++ b/packages/calendar/src/features/calendar/components/year-view/year-view.tsx
@@ -3,7 +3,6 @@ import { cn } from '@ilamy/ui/lib/utils'
 import dayjs, { type Dayjs } from '@ilamy/utils/dayjs'
 import { AnimatedSection } from '@/components/animations/animated-section'
 import { useSmartCalendarContext } from '@/features/calendar/hooks/use-smart-calendar-context'
-import { HEADER_STAGGER_DELAY } from '@/lib/constants'
 import { getDayKey, getWeekDays, isToday } from '@/lib/utils/date-utils'
 import { keys } from '@/lib/utils/keys'
 
@@ -137,9 +136,8 @@ export const YearView = () => {
 				className="grid auto-rows-fr grid-cols-1 gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3"
 				data-testid="year-grid"
 			>
-				{monthsData.map((month, monthIndex) => {
+				{monthsData.map((month) => {
 					const daysInMonth = generateDaysForMonth(month.date)
-					const animationDelay = monthIndex * HEADER_STAGGER_DELAY
 
 					return (
 						<div
@@ -149,7 +147,6 @@ export const YearView = () => {
 						>
 							<AnimatedSection
 								className="mb-2 flex items-center justify-between"
-								delay={animationDelay}
 								key={keys.listKey('month', month.monthKey)}
 								transitionKey={keys.listKey('month', month.monthKey)}
 							>

--- a/packages/calendar/src/lib/constants.ts
+++ b/packages/calendar/src/lib/constants.ts
@@ -23,14 +23,6 @@ export const WEEK_DAYS_NUMBER_MAP: Record<WeekDays, number> = {
 	saturday: 6,
 }
 
-// Per-item stagger (seconds) for AnimatedSection sequences in view headers and
-// the year grid. Previously the literal 0.05 pasted into 7 files.
-export const HEADER_STAGGER_DELAY = 0.05
-
-// Per-item stagger (seconds) for long hour sequences (a week of hour labels):
-// at HEADER_STAGGER_DELAY a 168-item row would take ~8s to finish animating.
-export const HOUR_STAGGER_DELAY = 0.005
-
 // Header height contract: one header row (day labels, hour labels) is h-12;
 // the grouped two-row header (day row stacked on hour row) must be exactly
 // 2x that — h-24. Change them together.


### PR DESCRIPTION
## Linked issue

n/a (maintainer)

## What changed?

View headers animated the wrong thing. `AnimatedSection` **was** the header cell, so it carried `bg-background`, `flex-1`, padding and hover styles, and the whole cell slid and faded in on every navigation. The year view read better because its `AnimatedSection` sits inside the month card and wraps only the title row, leaving the card's border, background and padding static.

Every header now follows that shape: a plain cell holds layout, background, `data-testid` and click handler, with `AnimatedSection` inside wrapping just the `DayLabel` / `HourLabel` / weekday span.

Also removed staggering everywhere, the year grid included, so animated elements enter together, and raised the enter duration from 200ms to 500ms.

- `TimeHeaderRow` lost its `delayStep` prop
- `HEADER_STAGGER_DELAY` and `HOUR_STAGGER_DELAY` are both deleted (the latter existed only so a 168-cell hour row would not cascade for ~8s)

## A regression this caught

Moving the animation inside the hour cell put a `w-full` wrapper between cell and text. `HourLabel` renders a bare text node with no element of its own, so it inherited alignment from that wrapper, which made the cell's `justify-center` a no-op and left hour labels pinned to the left edge of every column in the resource horizontal views. Fixed with `text-center` on the animated wrapper. `DayLabel` is immune because it centers its own content, which is why only the hour row broke.

## Notes

The 500ms duration lives in `AnimatedSection`, so it applies to all four consumers: header labels, the view-switch fade, year cards, and every event mount. If event mounts feel slow, the narrower fix is keeping the component at 200ms and passing `duration-500` per call site, which works because `cn` uses `twMerge`.

`duration-500` was verified to generate rather than silently falling back to the plugin's 150ms default: the built demo CSS contains `animation-duration:.5s`. The `tailwindcss-animate` plugin maps `duration-*` to `animationDuration` from `{0, ...theme('transitionDuration')}`.

`AnimatedSection` is otherwise untouched. Its `delay` prop is unused now but kept, since the component is shared and reworking it during a visual fix invites exactly the regression above.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [x] CI passes locally (`bun run ci`)
- [x] Changes are tested
- [x] Code follows project standards

New tests in `month.test.tsx` and `week.test.tsx` assert the cell carries no `animate-in`, an inner element does, and `animationDelay` is `0s`. Both were confirmed failing before the change. Full gate: 877 calendar, 172 recurrence, 56 drag-to-create, 19 agenda; type-check 0 errors; Biome clean; Fallow 0 issues on 13 changed files.