### PR TITLE
fix: give DndContext a stable id so server-rendered calendars hydrate

### DIFF
--- a/packages/calendar/src/components/drag-and-drop/calendar-dnd-context.ssr.test.tsx
+++ b/packages/calendar/src/components/drag-and-drop/calendar-dnd-context.ssr.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import type { CalendarEvent } from '@ilamy/types'
+import dayjs from '@ilamy/utils/dayjs'
+import { renderToString } from 'react-dom/server'
+import { IlamyCalendar } from '@/features/calendar/components/ilamy-calendar'
+
+/*
+ * dnd-kit numbers the ids behind `aria-describedby` from a module-level
+ * counter. A browser gets a fresh module per page load; a server does not, so
+ * the counter carries from one request to the next and the markup drifts away
+ * from what the client will produce. Rendering twice in one process is exactly
+ * what two successive requests do, so it is what this asserts.
+ */
+describe('CalendarDndContext server rendering', () => {
+	const events: CalendarEvent[] = [
+		{
+			id: 'a',
+			title: 'A',
+			start: dayjs('2025-03-31T10:00:00.000Z'),
+			end: dayjs('2025-03-31T11:00:00.000Z'),
+		},
+	]
+
+	const renderOnce = () =>
+		renderToString(
+			<IlamyCalendar
+				events={events}
+				initialDate={dayjs('2025-03-31')}
+				initialView="week"
+			/>
+		)
+
+	// Draggables are what carry the attribute, so the calendar needs an event
+	// on screen for this to be testing anything at all.
+	const describedByIds = (html: string) => [
+		...new Set(
+			[...html.matchAll(/aria-describedby="([^"]*)"/g)].map((match) =>
+				match.at(1)
+			)
+		),
+	]
+
+	test('emits the same describedby ids on every render', () => {
+		const first = describedByIds(renderOnce())
+		const second = describedByIds(renderOnce())
+		const third = describedByIds(renderOnce())
+
+		expect(first.length).toBeGreaterThan(0)
+		expect(second).toEqual(first)
+		expect(third).toEqual(first)
+	})
+})

--- a/packages/calendar/src/components/drag-and-drop/calendar-dnd-context.tsx
+++ b/packages/calendar/src/components/drag-and-drop/calendar-dnd-context.tsx
@@ -13,7 +13,7 @@ import {
 } from '@dnd-kit/core'
 import type { CalendarEvent } from '@ilamy/types'
 import type React from 'react'
-import { useRef } from 'react'
+import { useId, useRef } from 'react'
 import { EventMutationScopeSlot } from '@/components/calendar-slots'
 import { useSmartCalendarContext } from '@/features/calendar/hooks/use-smart-calendar-context'
 import { useScopedEventMutation } from '@/hooks/use-scoped-event-mutation'
@@ -25,6 +25,21 @@ interface CalendarDndContextProps {
 }
 
 export function CalendarDndContext({ children }: CalendarDndContextProps) {
+	/*
+	 * dnd-kit derives the `aria-describedby` it puts on every draggable from a
+	 * module-level counter that is never reset. In the browser that is fine —
+	 * the module is fresh per page load. On a server it is not: the module
+	 * lives for the life of the process, so the counter carries across
+	 * requests and the second render of a page emits `DndDescribedBy-1` where
+	 * the client, starting over at 0, emits `DndDescribedBy-0`. Every
+	 * server-rendered calendar after the first then fails to hydrate.
+	 *
+	 * `useId` is React's answer to exactly this: it derives the id from the
+	 * component's position in the tree, so server and client agree however many
+	 * requests the process has served. Passing it through means consumers do
+	 * not have to know any of this.
+	 */
+	const dndContextId = useId()
 	const activeEventRef = useRef<CalendarEvent>(null)
 	const dragOverlayRef = useRef<{
 		setActiveEvent: (event: CalendarEvent | null) => void
@@ -113,6 +128,7 @@ export function CalendarDndContext({ children }: CalendarDndContextProps) {
 		<>
 			<DndContext
 				collisionDetection={pointerWithin}
+				id={dndContextId}
 				onDragCancel={handleDragCancel}
 				onDragEnd={handleDragEnd}
 				onDragStart={handleDragStart}


### PR DESCRIPTION
## Linked issue

<!--
REQUIRED for contributions from outside the maintainer. Write `Closes #123`.
If no issue exists yet, open one first describing the problem, then link it here.
PRs without a linked issue will be asked for one before review.
Maintainer PRs may use `n/a`.
-->

Closes #261 

## The bug

`@dnd-kit/utilities` numbers the ids behind `aria-describedby` from a
module-level counter that is never reset:

```js
let ids = {}
const id = ids[prefix] == null ? 0 : ids[prefix] + 1
```

In a browser that is fine — the module is fresh on every page load. On a server
it is not. The module lives for the life of the process, so the counter carries
from one request to the next: the fourth render of a page emits
`DndDescribedBy-3` while the client, starting over at 0, emits
`DndDescribedBy-0`. Every server-rendered calendar after the process's first one
fails to hydrate.

The first load after a server restart is clean, which is why this reads as
intermittent in development and is permanent in production.

## The fix

`useUniqueId(prefix, value)` returns `value` untouched when one is given, and
`DndContext` forwards its `id` prop into it. So the fix is to hand it an id that
does not come from the counter, and `useId` is React's answer to exactly this —
it derives one from the component's position in the tree, which is the same on
both sides however many requests the process has served.

```tsx
const dndContextId = useId()
// ...
<DndContext id={dndContextId} … >
```

## Why not expose it as a prop

We could also expose the `DndContext` id on `IlamyCalendarProps`, and
that would work — but it would only fix consumers who already know why they need
it, which is nobody until they have debugged this. Everyone who server-renders
hits it, and the fix costs one hook, so doing it internally means people get it
by upgrading. Happy to add the prop as well if you want an escape hatch, but I
could not find a case that needs one.

## Test

Renders the calendar three times in one process — which is what three successive
requests do — and asserts the described-by ids do not move. It needs an event on
screen: the attribute lives on draggables, so an empty calendar would pass
whether or not this were fixed. Verified by removing the `id` and watching it go
red.

## AI disclaimer

I've used Claude Opus 5 to help with this PR.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Checklist

- [x] CI passes locally (`bun run ci`)
- [x] Changes are tested
- [x] Code follows project standards
