### PR TITLE
chore(claude): enable the kc-claude-kit plugins for everyone on the repo

### DIFF
--- a/.agents/settings.json
+++ b/.agents/settings.json
@@ -1,4 +1,18 @@
 {
+	"extraKnownMarketplaces": {
+		"kc-claude-kit": {
+			"source": {
+				"source": "github",
+				"repo": "kcsujeet/kc-claude-kit"
+			}
+		}
+	},
+	"enabledPlugins": {
+		"claude-md@kc-claude-kit": true,
+		"code-review@kc-claude-kit": true,
+		"conventions@kc-claude-kit": true,
+		"testing@kc-claude-kit": true
+	},
 	"permissions": {
 		"allow": [
 			"WebFetch(domain:docs.anthropic.com)",


### PR DESCRIPTION
## Linked issue

n/a (maintainer PR)

## What changed?

Registers the `kc-claude-kit` marketplace and switches on all four of its plugins in the repo's checked-in Claude settings (`.agents/settings.json`, which `.claude/settings.json` symlinks to):

- `claude-md` - audit a repo's Claude Code instruction setup
- `code-review` - gate-based review, one subagent per rule file
- `conventions` - portable coding conventions as path-scoped rules
- `testing` - verification workflows

## Why

The marketplace was registered in personal user settings but none of its plugins were enabled, so its skills never appeared in a session. In particular `code-review:review-code` was unavailable, and reviews fell back to the repo's own `.agents/skills/code-review` instead, which drafts PR comments in a different format.

Putting both keys in project settings means anyone who clones the repo gets the same set rather than each person wiring it up.

## Notes

- `extraKnownMarketplaces` is included on purpose. Enabling a plugin without registering its marketplace leaves teammates enabling a source they do not have. The settings schema documents this key as "typically used in repository `.claude/settings.json` to ensure team members have required plugin sources".
- Both keys are valid at project scope. Precedence is user < project < local, so anyone who wants one of these off locally can set it to `false` in `.claude/settings.local.json`.
- Note `code-review` is also the name of an enabled plugin from `claude-plugins-official`. They coexist; the skills are namespaced (`code-review:review-code` vs `code-review:code-review`).
- Existing `permissions` (16 allow rules) and `hooks` (Stop, plus both PreToolUse groups) are untouched. `jq` validates the file and the symlink still resolves.
- Takes effect after a plugin reload.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [x] 🔧 Maintenance